### PR TITLE
Fixed commit message pattern in commit-msg hook

### DIFF
--- a/.git-hooks/commit-msg.sh
+++ b/.git-hooks/commit-msg.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-commit_pattern="### What's done:"
+commit_pattern="(Merge (remote-tracking )?branch|### What's done:)"
 error_msg="Your commit message doesn't match the pattern $commit_pattern. Please fix it."
 
 if [[ ! $( cat "$1" ) =~ $commit_pattern ]]


### PR DESCRIPTION
### What's done:
* Changed pattern so that it allows local merging