### PR TITLE
Fix failing test with params.fileName being null

### DIFF
--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/KdocFormatting.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/KdocFormatting.kt
@@ -72,7 +72,7 @@ class KdocFormatting : Rule("kdoc-formatting") {
         configRules = params.getDiktatConfigRules()
         isFixMode = autoCorrect
         emitWarn = emit
-        fileName = params.fileName ?: ""
+        fileName = params.fileName!!
 
         val declarationTypes = setOf(CLASS, FUN, PROPERTY)
 

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/comments/HeaderCommentRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/comments/HeaderCommentRule.kt
@@ -45,7 +45,7 @@ class HeaderCommentRule : Rule("header-comment") {
         emitWarn = emit
 
         if (node.elementType == ElementType.FILE) {
-            fileName = params.fileName ?: ""
+            fileName = params.fileName!!
             checkCopyright(node)
             checkHeaderKdoc(node)
         }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter1/PackageNamingWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter1/PackageNamingWarnTest.kt
@@ -18,7 +18,6 @@ class PackageNamingWarnTest {
     )
 
     @Test
-    @Ignore("this test is failing because params.fileName!! throws NPE")
     fun `missing package name (check)`() {
         lintMethod(PackageNaming(),
             """
@@ -30,7 +29,7 @@ class PackageNamingWarnTest {
                 class TestPackageName {  }
 
             """.trimIndent(),
-            LintError(1, 1, ruleId, "${PACKAGE_NAME_MISSING.warnText()} "),
+            LintError(1, 1, ruleId, "${PACKAGE_NAME_MISSING.warnText()} /TestFileName.kt"),
             rulesConfigList = rulesConfigList
         )
     }


### PR DESCRIPTION
This closes #45 

### What's done:
* params.fileName is no more null in tests, fixed null safe access to it