### PR TITLE
Diktat should check it's own code

### DIFF
--- a/.github/workflows/diktat.yml
+++ b/.github/workflows/diktat.yml
@@ -1,0 +1,17 @@
+name: Run diktat
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Run diktat itself via ktlint
+        run: mvn antrun:run@diktat

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Add this snippet to your pom.xml:
         <version>1.8</version>
         <executions>
           <execution>
-            <id>ktlint</id>
+            <id>diktat</id>
             <phase>verify</phase>
             <configuration>
               <target name="ktlint">
@@ -112,6 +112,9 @@ Add this snippet to your pom.xml:
 
 In case you want to add autofixer with diKTat ruleset just extend
 the snippet above with `<arg value="-F"/>`.
+
+To check/fix code style - mvn antrun:run@diktat.
+
 
 ## Customizations via `rules-config.json`
 

--- a/pom.xml
+++ b/pom.xml
@@ -233,6 +233,51 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.8</version>
+                <executions>
+                    <execution>
+                        <id>ktlint</id>
+                        <phase>none</phase>
+                        <configuration>
+                            <target name="ktlint">
+                                <java taskname="ktlint" dir="${basedir}" fork="true" failonerror="true"
+                                      classpathref="maven.plugin.classpath" classname="com.pinterest.ktlint.Main">
+                                    <arg value="src/**/*.kt"/>
+                                </java>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.pinterest</groupId>
+                        <artifactId>ktlint</artifactId>
+                        <version>0.37.1</version>
+                        <exclusions>
+                            <!-- exclusions are needed so that custom artifacts from fork will be used -->
+                            <exclusion>
+                                <groupId>com.pinterest.ktlint</groupId>
+                                <artifactId>ktlint-core</artifactId>
+                            </exclusion>
+                            <exclusion>
+                                <groupId>com.pinterest.ktlint</groupId>
+                                <artifactId>ktlint-ruleset-standard</artifactId>
+                            </exclusion>
+                        </exclusions>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.cqfn.diktat</groupId>
+                        <artifactId>diktat-rules</artifactId>
+                        <version>1.0.0</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,12 @@
             <url>https://central.artipie.com/akuleshov7/diktat</url>
         </repository>
     </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>artipie</id>
+            <url>https://central.artipie.com/akuleshov7/diktat</url>
+        </pluginRepository>
+    </pluginRepositories>
 
     <build>
         <pluginManagement>
@@ -239,7 +245,7 @@
                 <version>1.8</version>
                 <executions>
                     <execution>
-                        <id>ktlint</id>
+                        <id>diktat</id>
                         <phase>none</phase>
                         <configuration>
                             <target name="ktlint">
@@ -258,7 +264,7 @@
                     <dependency>
                         <groupId>com.pinterest</groupId>
                         <artifactId>ktlint</artifactId>
-                        <version>0.37.1</version>
+                        <version>0.37.1-fork</version>
                         <exclusions>
                             <!-- exclusions are needed so that custom artifacts from fork will be used -->
                             <exclusion>


### PR DESCRIPTION
This will close #33 

### What's done:
* Initial configuration in pom.xml

### TODO:
* [x] Now diktat execution looks for `rules-config.json` in every submodule's `$basedir`, should be changed to single location
* [x] Change `pom.xml` snippet in README.md to more working example
* [x] (probably) also deploy `com.pinterest.ktlint` full jar to artipie with custom version to avoid exclusions in pom.xml
* [ ] Fixing code style might be blocked until some improvements are implemented, like #40, #64 .
* [ ] Actually fix issues found by diktat
* [x] Add `antrun:run@ktlint` to CI builds