### PR TITLE
Fix of #122 - warn about missing KDoc on method even if it cannot be autosuggested

### DIFF
--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/kdoc/KdocMethods.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/kdoc/KdocMethods.kt
@@ -122,7 +122,11 @@ class KdocMethods : Rule("kdoc-methods") {
 
         // if no tag failed, we have too little information to suggest KDoc - it would just be empty
         val anyTagFailed = paramCheckFailed || returnCheckFailed || throwsCheckFailed
-        if (kDoc == null && anyTagFailed) addKdocTemplate(node, name, missingParameters, explicitlyThrownExceptions, returnCheckFailed)
+        if (kDoc == null && anyTagFailed) {
+            addKdocTemplate(node, name, missingParameters, explicitlyThrownExceptions, returnCheckFailed)
+        } else if (kDoc == null) {
+            MISSING_KDOC_ON_FUNCTION.warn(configRules, emitWarn, false, name, node.startOffset)
+        }
     }
 
     private fun getMissingParameters(node: ASTNode, kDocTags: Collection<KDocTag>?): Collection<String?> {

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter2/KdocMethodsTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter2/KdocMethodsTest.kt
@@ -53,18 +53,18 @@ class KdocMethodsTest {
         lintMethod(KdocMethods(), validCode, fileName = "src/main/kotlin/org/cqfn/diktat/Example.kt")
         // no false positive triggers on annotations
         lintMethod(KdocMethods(), complexAnnotationCode,
-                LintError(1, 1, ruleId, "${KDOC_WITHOUT_PARAM_TAG.warnText()} doubleInt (a)", false),
-                LintError(1, 1, ruleId, "${KDOC_WITHOUT_RETURN_TAG.warnText()} doubleInt"),
-                LintError(1, 1, ruleId, "${KDOC_WITHOUT_THROWS_TAG.warnText()} doubleInt (IllegalStateException)"),
-                LintError(1, 1, ruleId, "${MISSING_KDOC_ON_FUNCTION.warnText()} doubleInt", false),
+                LintError(1, 1, ruleId, "${KDOC_WITHOUT_PARAM_TAG.warnText()} doubleInt (a)", true),
+                LintError(1, 1, ruleId, "${KDOC_WITHOUT_RETURN_TAG.warnText()} doubleInt", true),
+                LintError(1, 1, ruleId, "${KDOC_WITHOUT_THROWS_TAG.warnText()} doubleInt (IllegalStateException)", true),
+                LintError(1, 1, ruleId, "${MISSING_KDOC_ON_FUNCTION.warnText()} doubleInt", true),
                 fileName = "src/main/kotlin/org/cqfn/diktat/Example.kt"
         )
         // should check all .kt files unless both conditions on location and name are true
         lintMethod(KdocMethods(), funCode,
-                LintError(1, 1, ruleId, "${KDOC_WITHOUT_PARAM_TAG.warnText()} doubleInt (a)", false),
-                LintError(1, 1, ruleId, "${KDOC_WITHOUT_RETURN_TAG.warnText()} doubleInt"),
-                LintError(1, 1, ruleId, "${KDOC_WITHOUT_THROWS_TAG.warnText()} doubleInt (IllegalStateException)"),
-                LintError(1, 1, ruleId, "${MISSING_KDOC_ON_FUNCTION.warnText()} doubleInt", false),
+                LintError(1, 1, ruleId, "${KDOC_WITHOUT_PARAM_TAG.warnText()} doubleInt (a)", true),
+                LintError(1, 1, ruleId, "${KDOC_WITHOUT_RETURN_TAG.warnText()} doubleInt", true),
+                LintError(1, 1, ruleId, "${KDOC_WITHOUT_THROWS_TAG.warnText()} doubleInt (IllegalStateException)", true),
+                LintError(1, 1, ruleId, "${MISSING_KDOC_ON_FUNCTION.warnText()} doubleInt", true),
                 fileName = "src/test/kotlin/org/cqfn/diktat/Example.kt"
         )
         // should allow to set custom test dirs
@@ -103,7 +103,9 @@ class KdocMethodsTest {
             $funCode
         """.trimIndent()
 
-        lintMethod(KdocMethods(), invalidCode, LintError(1, 13, ruleId, "${KDOC_WITHOUT_PARAM_TAG.warnText()} doubleInt (a)"))
+        lintMethod(KdocMethods(), invalidCode,
+                LintError(1, 13, ruleId, "${KDOC_WITHOUT_PARAM_TAG.warnText()} doubleInt (a)", true)
+        )
     }
 
     @Test
@@ -121,8 +123,8 @@ class KdocMethodsTest {
             fun addInts(a: Int, b: Int): Int = a + b
         """.trimIndent()
 
-        lintMethod(KdocMethods(), invalidCode, LintError(1, 12, ruleId,
-                "${KDOC_WITHOUT_PARAM_TAG.warnText()} addInts (b)")
+        lintMethod(KdocMethods(), invalidCode,
+                LintError(1, 12, ruleId, "${KDOC_WITHOUT_PARAM_TAG.warnText()} addInts (b)", true)
         )
     }
 
@@ -140,7 +142,9 @@ class KdocMethodsTest {
             $funCode
         """.trimIndent()
 
-        lintMethod(KdocMethods(), invalidCode, LintError(1, 13, ruleId, "${KDOC_WITHOUT_RETURN_TAG.warnText()} doubleInt"))
+        lintMethod(KdocMethods(), invalidCode,
+                LintError(1, 13, ruleId, "${KDOC_WITHOUT_RETURN_TAG.warnText()} doubleInt", true)
+        )
     }
 
     @Test
@@ -163,7 +167,9 @@ class KdocMethodsTest {
             private val list = mutableListOf<Int>()
         """.trimIndent()
 
-        lintMethod(KdocMethods(), invalidCode, LintError(1, 12, ruleId, "${KDOC_WITHOUT_RETURN_TAG.warnText()} foo"))
+        lintMethod(KdocMethods(), invalidCode,
+                LintError(1, 12, ruleId, "${KDOC_WITHOUT_RETURN_TAG.warnText()} foo", true)
+        )
     }
 
     @Test
@@ -180,7 +186,9 @@ class KdocMethodsTest {
             $funCode
         """.trimIndent()
 
-        lintMethod(KdocMethods(), invalidCode, LintError(1, 13, ruleId, "${KDOC_WITHOUT_THROWS_TAG.warnText()} doubleInt (IllegalStateException)"))
+        lintMethod(KdocMethods(), invalidCode,
+                LintError(1, 13, ruleId, "${KDOC_WITHOUT_THROWS_TAG.warnText()} doubleInt (IllegalStateException)", true)
+        )
     }
 
     @Test
@@ -219,7 +227,9 @@ class KdocMethodsTest {
             }
         """.trimIndent()
 
-        lintMethod(KdocMethods(), invalidCode, LintError(1, 1, ruleId, "${KDOC_WITHOUT_THROWS_TAG.warnText()} doubleInt (IllegalAccessException)"))
+        lintMethod(KdocMethods(), invalidCode,
+                LintError(1, 1, ruleId, "${KDOC_WITHOUT_THROWS_TAG.warnText()} doubleInt (IllegalAccessException)", true)
+        )
     }
 
     @Test
@@ -275,10 +285,21 @@ class KdocMethodsTest {
                     |    }
                     |}
                 """.trimMargin(),
-                LintError(12, 5, ruleId, "${KDOC_WITHOUT_PARAM_TAG.warnText()} setY (y)"),
-                LintError(12, 5, ruleId, "${MISSING_KDOC_ON_FUNCTION.warnText()} setY"),
-                LintError(17, 5, ruleId, "${KDOC_WITHOUT_RETURN_TAG.warnText()} getZ"),
-                LintError(17, 5, ruleId, "${MISSING_KDOC_ON_FUNCTION.warnText()} getZ")
+                LintError(10, 5, ruleId, "${MISSING_KDOC_ON_FUNCTION.warnText()} getY", false),
+                LintError(12, 5, ruleId, "${KDOC_WITHOUT_PARAM_TAG.warnText()} setY (y)", true),
+                LintError(12, 5, ruleId, "${MISSING_KDOC_ON_FUNCTION.warnText()} setY", true),
+                LintError(17, 5, ruleId, "${KDOC_WITHOUT_RETURN_TAG.warnText()} getZ", true),
+                LintError(17, 5, ruleId, "${MISSING_KDOC_ON_FUNCTION.warnText()} getZ", true)
+        )
+    }
+
+    @Test
+    fun `regression - warn about missing KDoc even if it cannot be autocorrected`() {
+        lintMethod(KdocMethods(),
+                """
+                    |fun foo() { }
+                """.trimMargin(),
+                LintError(1, 1, ruleId, "${MISSING_KDOC_ON_FUNCTION.warnText()} foo", false)
         )
     }
 

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/util/TestUtils.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/util/TestUtils.kt
@@ -36,7 +36,8 @@ fun lintMethod(rule: Rule,
                     it.assertThat(actual.col).`as`("Column").isEqualTo(expected.col)
                     it.assertThat(actual.ruleId).`as`("Rule id").isEqualTo(expected.ruleId)
                     it.assertThat(actual.detail).`as`("Detailed message").isEqualTo(expected.detail)
-                    // fixme: in ktlint canBeAutoCorrected is not included in equals/hashCode for `backward compatibility`
+                    // fixme: fix all tests and uncomment
+//                    it.assertThat(actual.canBeAutoCorrected).`as`("Can be autocorrected").isEqualTo(expected.canBeAutoCorrected)
                 }
             }
 }


### PR DESCRIPTION
This closes #122 

### What's done:
* Changed logic
* Added tests