### PR TITLE
False trigger at underscores in identifier naming rule

### DIFF
--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/IdentifierNaming.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/IdentifierNaming.kt
@@ -156,7 +156,7 @@ class IdentifierNaming(private val configRules: List<RulesConfig>) : Rule("ident
                                 (variableName as LeafPsiElement).replaceWithText(variableName.text.toUpperSnakeCase())
                             }
                         }
-                    } else if (!variableName.text.isLowerCamelCase()) {
+                    } else if (variableName.text != "_" && !variableName.text.isLowerCamelCase()) {
                         // variable name should be in camel case. The only exception is a list of industry standard variables like i, j, k.
                         VARIABLE_NAME_INCORRECT_FORMAT.warnAndFix(configRules, emitWarn, isFixMode, variableName.text, variableName.startOffset) {
                             // FixMe: cover fixes with tests
@@ -358,7 +358,7 @@ class IdentifierNaming(private val configRules: List<RulesConfig>) : Rule("ident
     private fun checkIdentifierLength(nodes: List<ASTNode>,
                                       isVariable: Boolean) {
         nodes.forEach {
-            if (!(it.checkLength(MIN_IDENTIFIER_LENGTH..MAX_IDENTIFIER_LENGTH) ||
+            if (it.text != "_" && !(it.checkLength(MIN_IDENTIFIER_LENGTH..MAX_IDENTIFIER_LENGTH) ||
                             ONE_CHAR_IDENTIFIERS.contains(it.text) && isVariable || validCatchIdentifier(it)
 
                             )) {

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter1/IdentifierNamingWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter1/IdentifierNamingWarnTest.kt
@@ -504,6 +504,36 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
     }
 
     @Test
+    @Tag(WarningNames.BACKTICKS_PROHIBITED)
+    fun `should not trigger on underscore`() {
+        val code =
+                """
+                    class SomeClass {
+                        fun bar() {
+                            val ast = list.map {(first, _) -> foo(first)}
+                            
+                            var meanValue: Int = 0
+                                for ((
+                                    _,
+                                    _,
+                                    year, // trailing comma
+                                ) in cars) {
+                                    meanValue += year
+                                }
+                            
+                            try {
+                                /* ... */
+                            } catch (_: IOException) {
+                                /* ... */
+                            }
+                        }
+                    }
+                """.trimIndent()
+
+        lintMethod(code)
+    }
+
+    @Test
     @Tag(WarningNames.CONFUSING_IDENTIFIER_NAMING)
     fun `confusing identifier naming`() {
         val code =

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter1/IdentifierNamingWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter1/IdentifierNamingWarnTest.kt
@@ -504,7 +504,7 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
     }
 
     @Test
-    @Tag(WarningNames.BACKTICKS_PROHIBITED)
+    @Tag(WarningNames.VARIABLE_NAME_INCORRECT_FORMAT)
     fun `should not trigger on underscore`() {
         val code =
                 """

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter1/IdentifierNamingWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter1/IdentifierNamingWarnTest.kt
@@ -516,7 +516,7 @@ class IdentifierNamingWarnTest : LintTestBase(::IdentifierNaming) {
                                 for ((
                                     _,
                                     _,
-                                    year, // trailing comma
+                                    year
                                 ) in cars) {
                                     meanValue += year
                                 }


### PR DESCRIPTION
### What's done:
  * Fixed bugs in identifier naming false triggering on _
  * Added warn test

## Actions checklist
* [ ] Implemented Rule, added Warnings
* [X] Added tests on checks
* [ ] Added tests on fixers
* [ ] Updated diktat-analysis.yml
* [ ] Updated available-rules.md

Closes #88 
