### PR TITLE
Fixes to GPG handling in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,9 +33,8 @@ jobs:
           echo ::set-env name=RELEASE_VERSION::${GITHUB_REF#'refs/tags/v'}
           echo "$DIKTAT_GPG_PUB" > ~/diktat.pubring.gpg
           echo "$DIKTAT_GPG_SEC" > ~/diktat.secring.gpg
-          wc -l ~/diktat.pubring.gpg
           gpg --import ~/diktat.pubring.gpg
-          gpg --batch --yes --import ~/diktat.secring.gpg
+          gpg --batch --import ~/diktat.secring.gpg  # --batch suppresses intercatively asking passphrase
       - name: Set version
         run: mvn -B versions:set -DnewVersion=${{ env.RELEASE_VERSION }} versions:commit
       - name: Create settings.xml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,8 +30,9 @@ jobs:
           echo ::set-env name=RELEASE_VERSION::${GITHUB_REF#'refs/tags/v'}
           echo ${{ secrets.DIKTAT_GPG_PUB }} > ~/diktat.pubring.gpg
           echo ${{ secrets.DIKTAT_GPG_SEC }} > ~/diktat.secring.gpg
-          gpg --import ~/diktat.pubring.gpg
-          gpg --batch --import ~/diktat.secring.gpg
+          gpg --version
+          gpg --import ~/diktat.pubring.gpg && echo 'Succesfully imported public key'
+          gpg --batch --yes --import ~/diktat.secring.gpg && echo 'Successfully imported private key'
       - name: Set version
         run: mvn -B versions:set -DnewVersion=${{ env.RELEASE_VERSION }} versions:commit
       - name: Create settings.xml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Build release
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout
@@ -31,8 +31,8 @@ jobs:
           echo ${{ secrets.DIKTAT_GPG_PUB }} > ~/diktat.pubring.gpg
           echo ${{ secrets.DIKTAT_GPG_SEC }} > ~/diktat.secring.gpg
           gpg --version
-          gpg --import ~/diktat.pubring.gpg && echo 'Succesfully imported public key'
-          gpg --batch --yes --import ~/diktat.secring.gpg && echo 'Successfully imported private key'
+          gpg --import ~/diktat.pubring.gpg || echo 'Error importing public key'
+          gpg --batch --yes --import ~/diktat.secring.gpg || echo 'Error importing private key'
       - name: Set version
         run: mvn -B versions:set -DnewVersion=${{ env.RELEASE_VERSION }} versions:commit
       - name: Create settings.xml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,9 +30,8 @@ jobs:
           echo ::set-env name=RELEASE_VERSION::${GITHUB_REF#'refs/tags/v'}
           echo ${{ secrets.DIKTAT_GPG_PUB }} > ~/diktat.pubring.gpg
           echo ${{ secrets.DIKTAT_GPG_SEC }} > ~/diktat.secring.gpg
-          gpg --version
-          gpg --import ~/diktat.pubring.gpg || echo 'Error importing public key'
-          gpg --batch --yes --import ~/diktat.secring.gpg || echo 'Error importing private key'
+          gpg --import ~/diktat.pubring.gpg
+          gpg --batch --import ~/diktat.secring.gpg
       - name: Set version
         run: mvn -B versions:set -DnewVersion=${{ env.RELEASE_VERSION }} versions:commit
       - name: Create settings.xml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,11 +25,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-master-
       - name: Setup environment
+        env:
+          DIKTAT_GPG_PUB: ${{ secrets.DIKTAT_GPG_PUB }}
+          DIKTAT_GPG_SEC: ${{ secrets.DIKTAT_GPG_SEC }}
         run: |
           echo ::set-env name=PREVIOUS_VERSION::$(printf 'VERSION=${diktat-check.version}\n0\n' | mvn help:evaluate | grep '^VERSION' | cut -d= -f2)
           echo ::set-env name=RELEASE_VERSION::${GITHUB_REF#'refs/tags/v'}
-          echo ${{ secrets.DIKTAT_GPG_PUB }} > ~/diktat.pubring.gpg
-          echo ${{ secrets.DIKTAT_GPG_SEC }} > ~/diktat.secring.gpg
+          echo $DIKTAT_GPG_PUB > ~/diktat.pubring.gpg
+          echo $DIKTAT_GPG_SEC > ~/diktat.secring.gpg
           cat ~/diktat.pubring.gpg
           gpg --import ~/diktat.pubring.gpg
           gpg --batch --yes --import ~/diktat.secring.gpg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,15 +31,15 @@ jobs:
           echo ${{ secrets.DIKTAT_GPG_PUB }} > ~/diktat.pubring.gpg
           echo ${{ secrets.DIKTAT_GPG_SEC }} > ~/diktat.secring.gpg
           gpg --import ~/diktat.pubring.gpg
-          gpg --import ~/diktat.secring.gpg
+          gpg --batch --import ~/diktat.secring.gpg
       - name: Set version
         run: mvn -B versions:set -DnewVersion=${{ env.RELEASE_VERSION }} versions:commit
       - name: Create settings.xml
         uses: whelk-io/maven-settings-xml-action@v9
         with:
-          servers: '[{ "id": "ossrh", "username": "${{ secrets.SONATYPE_USER }}", "password": "${{ secrets.SONATYPE_PASSWORD }}" }, { "id": "gpg.passphrase", "passphrase": "${{ secrets.DIKTAT_GPG_PASS }}" }]'
+          servers: '[{ "id": "gpg.passphrase", "passphrase": "${{ secrets.DIKTAT_GPG_PASS }}" }]'
       - name: Deploy artifacts
-        run: mvn -B clean deploy -Prelease
+        run: mvn -B clean verify -Prelease
       - name: Create Github Release
         id: create_release
         uses: actions/create-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,8 @@ jobs:
             ${{ runner.os }}-maven-master-
       - name: Setup environment
         env:
-          DIKTAT_GPG_PUB: ${{ secrets.DIKTAT_GPG_PUB }}
-          DIKTAT_GPG_SEC: ${{ secrets.DIKTAT_GPG_SEC }}
+          DIKTAT_GPG_PUB: ${{ secrets.DIKTAT_PGP_PUB }}
+          DIKTAT_GPG_SEC: ${{ secrets.DIKTAT_PGP_SEC }}
         run: |
           echo ::set-env name=PREVIOUS_VERSION::$(printf 'VERSION=${diktat-check.version}\n0\n' | mvn help:evaluate | grep '^VERSION' | cut -d= -f2)
           echo ::set-env name=RELEASE_VERSION::${GITHUB_REF#'refs/tags/v'}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,9 +40,9 @@ jobs:
       - name: Create settings.xml
         uses: whelk-io/maven-settings-xml-action@v9
         with:
-          servers: '[{ "id": "gpg.passphrase", "passphrase": "${{ secrets.DIKTAT_GPG_PASS }}" }]'
+          servers: '[{ "id": "ossrh", "username": "${{ secrets.SONATYPE_USER }}", "password": "${{ secrets.SONATYPE_PASSWORD }}" }, { "id": "gpg.passphrase", "passphrase": "${{ secrets.DIKTAT_GPG_PASS }}" }]'
       - name: Deploy artifacts
-        run: mvn -B clean verify -Prelease
+        run: mvn -B clean deploy -Prelease
       - name: Create Github Release
         id: create_release
         uses: actions/create-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,8 +30,9 @@ jobs:
           echo ::set-env name=RELEASE_VERSION::${GITHUB_REF#'refs/tags/v'}
           echo ${{ secrets.DIKTAT_GPG_PUB }} > ~/diktat.pubring.gpg
           echo ${{ secrets.DIKTAT_GPG_SEC }} > ~/diktat.secring.gpg
+          cat ~/diktat.pubring.gpg
           gpg --import ~/diktat.pubring.gpg
-          gpg --batch --import ~/diktat.secring.gpg
+          gpg --batch --yes --import ~/diktat.secring.gpg
       - name: Set version
         run: mvn -B versions:set -DnewVersion=${{ env.RELEASE_VERSION }} versions:commit
       - name: Create settings.xml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,9 +31,9 @@ jobs:
         run: |
           echo ::set-env name=PREVIOUS_VERSION::$(printf 'VERSION=${diktat-check.version}\n0\n' | mvn help:evaluate | grep '^VERSION' | cut -d= -f2)
           echo ::set-env name=RELEASE_VERSION::${GITHUB_REF#'refs/tags/v'}
-          echo $DIKTAT_GPG_PUB > ~/diktat.pubring.gpg
-          echo $DIKTAT_GPG_SEC > ~/diktat.secring.gpg
-          cat ~/diktat.pubring.gpg
+          echo "$DIKTAT_GPG_PUB" > ~/diktat.pubring.gpg
+          echo "$DIKTAT_GPG_SEC" > ~/diktat.secring.gpg
+          wc -l ~/diktat.pubring.gpg
           gpg --import ~/diktat.pubring.gpg
           gpg --batch --yes --import ~/diktat.secring.gpg
       - name: Set version


### PR DESCRIPTION
### What's done:
* Correctly use github secrets via env variables
* Added `--batch` option to suppress interactive passphrase prompt

Successfully tested on fork: [workflow run](https://github.com/petertrr/diKTat/runs/1107927690?check_suite_focus=true)