### PR TITLE
Bugfix. Do not check KDoc on method main

### DIFF
--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/kdoc/KdocComments.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/kdoc/KdocComments.kt
@@ -278,9 +278,16 @@ class KdocComments(private val configRules: List<RulesConfig>) : Rule("kdoc-comm
         val modifier = node.getFirstChildWithType(MODIFIER_LIST)
         val name = node.getIdentifierName()
 
-        if (modifier.isAccessibleOutside() && kdoc == null) {
+        if (modifier.isAccessibleOutside() && kdoc == null && !isTopLevelFunctionStandard(node)) {
             warning.warn(configRules, emitWarn, isFixMode, name!!.text, node.startOffset, node)
         }
+    }
+
+    private fun isTopLevelFunctionStandard(node: ASTNode) : Boolean {
+        if (node.elementType == FUN) {
+            return node.isStandardMethod()
+        }
+        return false
     }
     companion object {
         private val statementsToDocument = TokenSet.create(CLASS, FUN, PROPERTY)

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/kdoc/KdocComments.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/kdoc/KdocComments.kt
@@ -283,12 +283,8 @@ class KdocComments(private val configRules: List<RulesConfig>) : Rule("kdoc-comm
         }
     }
 
-    private fun isTopLevelFunctionStandard(node: ASTNode) : Boolean {
-        if (node.elementType == FUN) {
-            return node.isStandardMethod()
-        }
-        return false
-    }
+    private fun isTopLevelFunctionStandard(node: ASTNode) : Boolean = node.elementType == FUN && node.isStandardMethod()
+
     companion object {
         private val statementsToDocument = TokenSet.create(CLASS, FUN, PROPERTY)
     }

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/FunctonASTNodeUtils.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/FunctonASTNodeUtils.kt
@@ -9,6 +9,7 @@ import com.pinterest.ktlint.core.ast.ElementType.MODIFIER_LIST
 import org.cqfn.diktat.ruleset.rules.PackageNaming.Companion.PACKAGE_PATH_ANCHOR
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.psi.KtFunction
+import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.psi.KtParameterList
 
@@ -53,8 +54,8 @@ fun ASTNode.isGetterOrSetter(): Boolean {
  * Check whether this function is a standard method
  */
 fun ASTNode.isStandardMethod() = also(::checkNodeIsFun)
-        .getIdentifierName()
-        ?.let { it.text in STANDARD_METHODS }
+        .let { (it.psi as KtNamedFunction).name }
+        ?.let { it in STANDARD_METHODS }
         ?: false
 
 private fun ASTNode.argList(): ASTNode? {

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/FunctonASTNodeUtils.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/FunctonASTNodeUtils.kt
@@ -9,7 +9,6 @@ import com.pinterest.ktlint.core.ast.ElementType.MODIFIER_LIST
 import org.cqfn.diktat.ruleset.rules.PackageNaming.Companion.PACKAGE_PATH_ANCHOR
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.psi.KtFunction
-import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.psi.KtParameterList
 
@@ -54,8 +53,8 @@ fun ASTNode.isGetterOrSetter(): Boolean {
  * Check whether this function is a standard method
  */
 fun ASTNode.isStandardMethod() = also(::checkNodeIsFun)
-        .let { (it.psi as KtNamedFunction).name }
-        ?.let { it in STANDARD_METHODS }
+        .getIdentifierName()
+        ?.let { it.text in STANDARD_METHODS }
         ?: false
 
 private fun ASTNode.argList(): ASTNode? {

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter2/KdocWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter2/KdocWarnTest.kt
@@ -65,6 +65,8 @@ class KdocWarnTest : LintTestBase(::KdocComments) {
                     internal fun someGoodNameNew(): String {
                         return " ";
                     }
+                    
+                    fun main() {}
                 """.trimIndent()
         lintMethod(code,
                 LintError(1, 1, ruleId, "${MISSING_KDOC_TOP_LEVEL.warnText()} someGoodName"),

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter2/KdocWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter2/KdocWarnTest.kt
@@ -116,6 +116,8 @@ class KdocWarnTest : LintTestBase(::KdocComments) {
 
                         private class InternalClass {
                         }
+                        
+                        public fun main() {}
                     }
                 """.trimIndent()
         lintMethod(code,


### PR DESCRIPTION
## What's done
Fixed bug that MISSING_KDOC_TOP_LEVEL still checks fun main for documentation

This pull request closes #89 
