### PR TITLE
Support kotlin multiplatform project layout in PackageNaming rule

### DIFF
--- a/diktat-common/src/main/kotlin/org/cqfn/diktat/common/config/rules/RulesConfigReader.kt
+++ b/diktat-common/src/main/kotlin/org/cqfn/diktat/common/config/rules/RulesConfigReader.kt
@@ -115,6 +115,11 @@ data class CommonConfiguration(private val configuration: Map<String, String>?) 
     val domainName: String by lazy {
         (configuration ?: mapOf()).getOrDefault("domainName", "")
     }
+
+    /**
+     * False if configuration has been read from config file, true if defaults are used
+     */
+    val isDefault = configuration == null
 }
 
 // ================== utils for List<RulesConfig> from yml config
@@ -130,7 +135,7 @@ fun List<RulesConfig>.getRuleConfig(rule: Rule): RulesConfig? = this.find { it.n
 /**
  * Get [RulesConfig] representing common configuration part that can be used in any rule
  */
-fun List<RulesConfig>.getCommonConfig() = find { it.name == DIKTAT_COMMON }
+private fun List<RulesConfig>.getCommonConfig() = find { it.name == DIKTAT_COMMON }
 
 /**
  * checking if in yml config particular rule is enabled or disabled

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/PackageNaming.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/PackageNaming.kt
@@ -98,12 +98,10 @@ class PackageNaming(private val configRules: List<RulesConfig>) : Rule("package-
         } else {
             // creating a real package name:
             // 1) getting a path after the base project directory (after "src" directory)
-            // 2) removing src/main/kotlin/java/e.t.c dirs (additional check for multiplatform project layout) and removing file name
+            // 2) removing src/main/kotlin/java/e.t.c dirs and removing file name
             // 3) adding company's domain name at the beginning
             val fileSubDir = filePathParts.subList(filePathParts.lastIndexOf(PACKAGE_PATH_ANCHOR), filePathParts.size - 1)
-                    .dropWhile {
-                        LANGUAGE_DIR_NAMES.contains(it) || it.endsWith("Main") || it.endsWith("Test")
-                    }
+                    .dropWhile { LANGUAGE_DIR_NAMES.contains(it) }
             // no need to add DOMAIN_NAME to the package name if it is already in path
             val domainPrefix = if (!fileSubDir.joinToString(PACKAGE_SEPARATOR).startsWith(domainName)) domainName.split(PACKAGE_SEPARATOR) else listOf()
             domainPrefix + fileSubDir
@@ -239,10 +237,17 @@ class PackageNaming(private val configRules: List<RulesConfig>) : Rule("package-
         const val PACKAGE_PATH_ANCHOR = "src"
 
         /**
-         * Directories that are supposed to be first in sources file paths, relative to [PACKAGE_PATH_ANCHOR].
-         * This is a fixed set of directories, which should be later enhanced with patterns `*Main` and `*Test` for kotlin multiplatform project structure support.
+         * Targets described in [KMM documentation](https://kotlinlang.org/docs/reference/mpp-supported-platforms.html)
          */
-        val LANGUAGE_DIR_NAMES = listOf("src", "main", "test", "java", "kotlin")
+        private val kmmTargets = listOf("common", "jvm", "js", "android", "ios", "androidNativeArm32", "androidNativeArm64", "iosArm32", "iosArm64", "iosX64",
+            "watchosArm32", "watchosArm64", "watchosX86", "tvosArm64", "tvosX64", "macosX64", "linuxArm64", "linuxArm32Hfp", "linuxMips32", "linuxMipsel32", "linuxX64",
+            "mingwX64", "mingwX86", "wasm32")
+
+        /**
+         * Directories that are supposed to be first in sources file paths, relative to [PACKAGE_PATH_ANCHOR].
+         * For kotlin multiplatform projects directories for targets from [kmmTargets] are supported.
+         */
+        val LANGUAGE_DIR_NAMES = listOf("src", "main", "test", "java", "kotlin") + kmmTargets.flatMap { listOf("${it}Main", "${it}Test") }
 
         private val log = LoggerFactory.getLogger(PackageNaming::class.java)
     }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter1/PackageNamingWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter1/PackageNamingWarnTest.kt
@@ -211,4 +211,17 @@ class PackageNamingWarnTest : LintTestBase(::PackageNaming) {
             )
         }
     }
+
+    @Test
+    @Tag(WarningNames.PACKAGE_NAME_INCORRECT_PATH)
+    fun `should respect KMP project structure - illegal source set name`() {
+        lintMethod(
+            """
+                |package org.cqfn.diktat
+            """.trimMargin(),
+            LintError(1, 9, ruleId, "${PACKAGE_NAME_INCORRECT_PATH.warnText()} org.cqfn.diktat.myProjectMain.kotlin.org.cqfn.diktat.example", true),
+            fileName = "/home/testu/project/src/myProjectMain/kotlin/org/cqfn/diktat/example/Example.kt",
+            rulesConfigList = rulesConfigList
+        )
+    }
 }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter1/PackageNamingWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter1/PackageNamingWarnTest.kt
@@ -182,4 +182,33 @@ class PackageNamingWarnTest : LintTestBase(::PackageNaming) {
                 )
         )
     }
+
+    @Test
+    @Tag(WarningNames.PACKAGE_NAME_INCORRECT_PATH)
+    fun `should respect KMP project structure - positive example`() {
+        listOf("main", "test", "jvmMain", "jvmTest", "androidMain", "androidTest", "iosMain", "iosTest", "jsMain", "jsTest", "commonMain", "commonTest").forEach {
+            lintMethod(
+                """
+                    |package org.cqfn.diktat
+                """.trimMargin(),
+                fileName = "/home/testu/project/src/$it/kotlin/org/cqfn/diktat/Example.kt",
+                rulesConfigList = rulesConfigList
+            )
+        }
+    }
+
+    @Test
+    @Tag(WarningNames.PACKAGE_NAME_INCORRECT_PATH)
+    fun `should respect KMP project structure`() {
+        listOf("main", "test", "jvmMain", "jvmTest", "androidMain", "androidTest", "iosMain", "iosTest", "jsMain", "jsTest", "commonMain", "commonTest").forEach {
+            lintMethod(
+                """
+                    |package org.cqfn.diktat
+                """.trimMargin(),
+                LintError(1, 9, ruleId, "${PACKAGE_NAME_INCORRECT_PATH.warnText()} org.cqfn.diktat.example", true),
+                fileName = "/home/testu/project/src/$it/kotlin/org/cqfn/diktat/example/Example.kt",
+                rulesConfigList = rulesConfigList
+            )
+        }
+    }
 }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/smoke/DiktatSmokeTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/smoke/DiktatSmokeTest.kt
@@ -103,6 +103,13 @@ class DiktatSmokeTest : FixTestBase("test/smoke/src/main/kotlin",
         fixAndCompare("DefaultPackageExpected.kt", "DefaultPackageTest.kt")
     }
 
+    @Test
+    @Tag("DiktatRuleSetProvider")
+    fun `smoke test with multiplatform project layout`() {
+        fixAndCompare("../../jsMain/kotlin/org/cqfn/diktat/scripts/ScriptExpected.kt",
+        "../../jsMain/kotlin/org/cqfn/diktat/scripts/ScriptTest.kt")
+    }
+
     @AfterEach
     fun `revert configuration file to default`() {
         configFilePath = DEFAULT_CONFIG_PATH

--- a/diktat-rules/src/test/resources/test/smoke/src/jsMain/kotlin/org/cqfn/diktat/scripts/ScriptExpected.kt
+++ b/diktat-rules/src/test/resources/test/smoke/src/jsMain/kotlin/org/cqfn/diktat/scripts/ScriptExpected.kt
@@ -1,0 +1,8 @@
+package org.cqfn.diktat.scripts
+
+import kotlinx.browser.document
+
+fun main() {
+    (document.getElementById("myId") as HTMLElement).click()
+}
+

--- a/diktat-rules/src/test/resources/test/smoke/src/jsMain/kotlin/org/cqfn/diktat/scripts/ScriptTest.kt
+++ b/diktat-rules/src/test/resources/test/smoke/src/jsMain/kotlin/org/cqfn/diktat/scripts/ScriptTest.kt
@@ -1,0 +1,7 @@
+package org.cqfn.diktat.js
+
+import kotlinx.browser.document
+
+fun main() {
+    (document.getElementById("myId") as HTMLElement).click()
+}


### PR DESCRIPTION
### What's done:
* Added logic
* Added tests

This pull request closes #397 