### PR TITLE
Fixing diktat-gradle-plugin

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -3,9 +3,6 @@ name: Build and test
 on:
   pull_request
 
-env:
-  GRADLE_OPTS: -Dorg.gradle.daemon=false
-
 jobs:
   test:
     name: Unit Test

--- a/diktat-gradle-plugin/build.gradle.kts
+++ b/diktat-gradle-plugin/build.gradle.kts
@@ -104,7 +104,7 @@ tasks.getByName<Test>("functionalTest") {
     }
     finalizedBy(jacocoMergeTask)
 }
-tasks.check { dependsOn(functionalTestTask) }
+tasks.check { dependsOn(tasks.jacocoTestReport) }
 jacocoTestKit {
     applyTo("functionalTestRuntimeOnly", tasks.named("functionalTest"))
 }

--- a/diktat-gradle-plugin/build.gradle.kts
+++ b/diktat-gradle-plugin/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     implementation("org.cqfn.diktat:diktat-rules:$diktatVersion")
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")
+    testImplementation(gradleTestKit())
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
 }
 

--- a/diktat-gradle-plugin/build.gradle.kts
+++ b/diktat-gradle-plugin/build.gradle.kts
@@ -101,6 +101,7 @@ val functionalTest = sourceSets.create("functionalTest") {
         runtimeClasspath += output + compileClasspath
 }
 tasks.getByName<Test>("functionalTest") {
+    dependsOn("test")
     testClassesDirs = functionalTest.output.classesDirs
     classpath = functionalTest.runtimeClasspath
 }

--- a/diktat-gradle-plugin/build.gradle.kts
+++ b/diktat-gradle-plugin/build.gradle.kts
@@ -84,15 +84,6 @@ tasks.withType<Test> {
     useJUnitPlatform()
 }
 
-tasks.jacocoTestReport {
-    dependsOn(functionalTestTask)
-    reports {
-        // xml report is used by codecov
-        xml.isEnabled = true
-        xml.destination = file("target/site/jacoco/jacoco.xml")
-    }
-}
-
 // === integration testing
 // fixme: should probably use KotlinSourceSet instead
 val functionalTest = sourceSets.create("functionalTest") {
@@ -115,4 +106,16 @@ tasks.getByName<Test>("functionalTest") {
 tasks.check { dependsOn(functionalTestTask) }
 jacocoTestKit {
     applyTo("functionalTestRuntimeOnly", tasks.named("functionalTest"))
+}
+tasks.create("jacocoMerge", JacocoMerge::class) {
+    dependsOn(functionalTestTask)
+    executionData(tasks.test, functionalTestTask)
+}
+tasks.jacocoTestReport {
+    dependsOn("jacocoMerge")
+    executionData("$buildDir/jacoco/jacocoMerge.exec")
+    reports {
+        // xml report is used by codecov
+        xml.isEnabled = true
+    }
 }

--- a/diktat-gradle-plugin/build.gradle.kts
+++ b/diktat-gradle-plugin/build.gradle.kts
@@ -80,6 +80,7 @@ java {
 
 // === testing & code coverage, jacoco is run independent from maven
 val functionalTestTask by tasks.register<Test>("functionalTest")
+val jacocoMergeTask by tasks.register<JacocoMerge>("jacocoMerge")
 tasks.withType<Test> {
     useJUnitPlatform()
 }
@@ -101,18 +102,18 @@ tasks.getByName<Test>("functionalTest") {
             Thread.sleep(5_000)
         }
     }
-    finalizedBy(tasks.jacocoTestReport)
+    finalizedBy(jacocoMergeTask)
 }
 tasks.check { dependsOn(functionalTestTask) }
 jacocoTestKit {
     applyTo("functionalTestRuntimeOnly", tasks.named("functionalTest"))
 }
-tasks.create("jacocoMerge", JacocoMerge::class) {
+tasks.getByName("jacocoMerge", JacocoMerge::class) {
     dependsOn(functionalTestTask)
     executionData(tasks.test, functionalTestTask)
 }
 tasks.jacocoTestReport {
-    dependsOn("jacocoMerge")
+    dependsOn(jacocoMergeTask)
     executionData("$buildDir/jacoco/jacocoMerge.exec")
     reports {
         // xml report is used by codecov

--- a/diktat-gradle-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/diktat-gradle-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/diktat-gradle-plugin/pom.xml
+++ b/diktat-gradle-plugin/pom.xml
@@ -72,7 +72,7 @@
                             <executable>${gradle.executable}</executable>
                             <arguments>
                                 <argument>clean</argument>
-                                <argument>jacocoTestReport</argument>
+                                <argument>test</argument>
                                 <argument>-Pgroup=${project.groupId}</argument>
                                 <argument>-Pversion=${project.version}</argument>
                                 <argument>-Pdescription=${project.description}</argument>

--- a/diktat-gradle-plugin/pom.xml
+++ b/diktat-gradle-plugin/pom.xml
@@ -18,6 +18,9 @@
         <gradle.task>build</gradle.task>
         <gradle.builddir>build</gradle.builddir>
         <skip.gradle.build>false</skip.gradle.build>
+        <skip.gradle.test>false</skip.gradle.test>
+        <!-- This property is set to excluded task in the specific build profile -->
+        <gradle.exclude.check></gradle.exclude.check>
     </properties>
 
     <dependencies>
@@ -77,7 +80,7 @@
                                 <argument>-PjunitVersion=${junit.version}</argument>
                                 <argument>-S</argument>
                             </arguments>
-                            <skip>${skip.gradle.build}</skip>
+                            <skip>${skip.gradle.test}</skip>
                         </configuration>
                         <goals>
                             <goal>exec</goal>
@@ -96,6 +99,7 @@
                                 <argument>-PktlintVersion=${ktlint.version}</argument>
                                 <argument>-PjunitVersion=${junit.version}</argument>
                                 <argument>-S</argument>
+                                <argument>${gradle.exclude.check}</argument>
                             </arguments>
                             <skip>${skip.gradle.build}</skip>
                         </configuration>
@@ -183,6 +187,19 @@
             </activation>
             <properties>
                 <gradle.executable>${project.basedir}/gradlew.bat</gradle.executable>
+            </properties>
+        </profile>
+        <profile>
+            <id>skip-gradle-tests</id>
+            <activation>
+                <property>
+                    <name>skipTests</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <properties>
+                <gradle.exclude.check>-xcheck</gradle.exclude.check>
+                <skip.gradle.test>true</skip.gradle.test>
             </properties>
         </profile>
     </profiles>

--- a/diktat-gradle-plugin/src/functionalTest/kotlin/org/cqfn/diktat/plugin/gradle/DiktatGradlePluginFunctionalTest.kt
+++ b/diktat-gradle-plugin/src/functionalTest/kotlin/org/cqfn/diktat/plugin/gradle/DiktatGradlePluginFunctionalTest.kt
@@ -12,14 +12,16 @@ import java.io.File
 
 class DiktatGradlePluginFunctionalTest {
     private val testProjectDir = TemporaryFolder()
+    private lateinit var buildFile: File
 
     @BeforeEach
     fun setUp() {
         testProjectDir.create()
         File("../examples/gradle-kotlin-dsl").copyRecursively(testProjectDir.root)
         File(testProjectDir.root, "build.gradle.kts").delete()
-        testProjectDir.newFile("build.gradle.kts").writeText(
-            """
+        buildFile = testProjectDir.newFile("build.gradle.kts").apply {
+            writeText(
+                """
                 plugins {
                     id("org.cqfn.diktat.diktat-gradle-plugin")
                 }
@@ -29,8 +31,8 @@ class DiktatGradlePluginFunctionalTest {
                     mavenCentral()
                 }
             """.trimIndent()
-        )
-
+            )
+        }
     }
 
     @AfterEach
@@ -40,33 +42,7 @@ class DiktatGradlePluginFunctionalTest {
 
     @Test
     fun `should execute diktatCheck on default values`() {
-        println(testProjectDir.root.listFiles().joinToString("\n"))
-        val result = GradleRunner.create()
-            .withProjectDir(testProjectDir.root)
-            .withArguments(DIKTAT_CHECK_TASK)
-            .withPluginClasspath()
-            .forwardOutput()
-            .runCatching {
-                buildAndFail()
-            }
-
-        require(result.isSuccess) { "Running gradle returned exception ${result.exceptionOrNull()}" }
-
-        val buildResult = result.getOrNull()!!
-        val diktatCheckBuildResult = buildResult.task(":$DIKTAT_CHECK_TASK")
-        requireNotNull(diktatCheckBuildResult)
-        Assertions.assertEquals(TaskOutcome.FAILED, diktatCheckBuildResult.outcome)
-        Assertions.assertTrue(
-            buildResult.output.contains("[HEADER_MISSING_OR_WRONG_COPYRIGHT]")
-        )
-    }
-
-/*    @Test
-    fun `should execute diktatCheck with explicit inputs`() {
-        val result = GradleRunner.create()
-            .withProjectDir(testProjectDir.root)
-            .withArguments(DIKTAT_CHECK_TASK)
-            .buildAndFail()
+        val result = runDiktat()
 
         val diktatCheckBuildResult = result.task(":$DIKTAT_CHECK_TASK")
         requireNotNull(diktatCheckBuildResult)
@@ -74,5 +50,37 @@ class DiktatGradlePluginFunctionalTest {
         Assertions.assertTrue(
             result.output.contains("[HEADER_MISSING_OR_WRONG_COPYRIGHT]")
         )
-    }*/
+    }
+
+    @Test
+    fun `should execute diktatCheck with explicit inputs`() {
+        buildFile.appendText(
+            """${System.lineSeparator()}
+                diktat {
+                    inputs = files("src/**/*.kt")
+                }
+            """.trimIndent()
+        )
+        val result = runDiktat()
+
+        val diktatCheckBuildResult = result.task(":$DIKTAT_CHECK_TASK")
+        requireNotNull(diktatCheckBuildResult)
+        Assertions.assertEquals(TaskOutcome.FAILED, diktatCheckBuildResult.outcome)
+        Assertions.assertTrue(
+            result.output.contains("[HEADER_MISSING_OR_WRONG_COPYRIGHT]")
+        )
+    }
+
+    private fun runDiktat() = GradleRunner.create()
+        .withProjectDir(testProjectDir.root)
+        .withArguments(DIKTAT_CHECK_TASK)
+        .withPluginClasspath()
+        .forwardOutput()
+        .runCatching {
+            buildAndFail()
+        }
+        .also {
+            require(it.isSuccess) { "Running gradle returned exception ${it.exceptionOrNull()}" }
+        }
+        .getOrNull()!!
 }

--- a/diktat-gradle-plugin/src/functionalTest/kotlin/org/cqfn/diktat/plugin/gradle/DiktatGradlePluginFunctionalTest.kt
+++ b/diktat-gradle-plugin/src/functionalTest/kotlin/org/cqfn/diktat/plugin/gradle/DiktatGradlePluginFunctionalTest.kt
@@ -25,6 +25,7 @@ class DiktatGradlePluginFunctionalTest {
                 }
                 
                 repositories {
+                    mavenLocal()
                     mavenCentral()
                 }
             """.trimIndent()

--- a/diktat-gradle-plugin/src/functionalTest/kotlin/org/cqfn/diktat/plugin/gradle/DiktatGradlePluginFunctionalTest.kt
+++ b/diktat-gradle-plugin/src/functionalTest/kotlin/org/cqfn/diktat/plugin/gradle/DiktatGradlePluginFunctionalTest.kt
@@ -75,6 +75,7 @@ class DiktatGradlePluginFunctionalTest {
         .withProjectDir(testProjectDir.root)
         .withArguments(DIKTAT_CHECK_TASK)
         .withPluginClasspath()
+        .withJaCoCo()
         .forwardOutput()
         .runCatching {
             buildAndFail()
@@ -83,4 +84,18 @@ class DiktatGradlePluginFunctionalTest {
             require(it.isSuccess) { "Running gradle returned exception ${it.exceptionOrNull()}" }
         }
         .getOrNull()!!
+
+    /**
+     * This is support for jacoco reports in tests run with gradle TestKit
+     */
+    private fun GradleRunner.withJaCoCo() = apply {
+        javaClass.classLoader
+            .getResourceAsStream("testkit-gradle.properties")
+            .also { it ?: println("properties file for testkit is not available, check build configuration") }
+            ?.use { propertiesFileStream ->
+                File(projectDir, "gradle.properties").outputStream().use {
+                    propertiesFileStream.copyTo(it)
+                }
+            }
+    }
 }

--- a/diktat-gradle-plugin/src/main/kotlin/org/cqfn/diktat/plugin/gradle/DiktatJavaExecTaskBase.kt
+++ b/diktat-gradle-plugin/src/main/kotlin/org/cqfn/diktat/plugin/gradle/DiktatJavaExecTaskBase.kt
@@ -68,7 +68,8 @@ open class DiktatJavaExecTaskBase @Inject constructor(
                 }
                 .files
                 .forEach {
-                    add("\"${it.path}\"")
+                    val path = it.relativeTo(project.projectDir).path
+                    add("\"$path\"")
                 }
             diktatExtension.excludes?.files?.forEach {
                 add("\"!${it.path}\"")

--- a/diktat-gradle-plugin/src/main/kotlin/org/cqfn/diktat/plugin/gradle/DiktatJavaExecTaskBase.kt
+++ b/diktat-gradle-plugin/src/main/kotlin/org/cqfn/diktat/plugin/gradle/DiktatJavaExecTaskBase.kt
@@ -68,11 +68,10 @@ open class DiktatJavaExecTaskBase @Inject constructor(
                 }
                 .files
                 .forEach {
-                    val path = it.relativeTo(project.projectDir).path
-                    add("\"$path\"")
+                    add("\"${project.trimRootDir(it.path)}\"")
                 }
             diktatExtension.excludes?.files?.forEach {
-                add("\"!${it.path}\"")
+                add("\"!${project.trimRootDir(it.path)}\"")
             }
         }
         logger.debug("Setting JavaExec args to $args")
@@ -125,3 +124,10 @@ fun Project.registerDiktatFixTask(diktatExtension: DiktatExtension, diktatConfig
             DIKTAT_FIX_TASK, DiktatJavaExecTaskBase::class.java, gradle.gradleVersion,
             diktatExtension, diktatConfiguration, listOf("-F ")
         )
+
+private fun Project.trimRootDir(path: String) = if (path.startsWith(rootDir.absolutePath)) {
+    path.drop(rootDir.absolutePath.length)
+} else {
+    path
+}
+    .trim(File.separatorChar)

--- a/diktat-gradle-plugin/src/main/kotlin/org/cqfn/diktat/plugin/gradle/DiktatJavaExecTaskBase.kt
+++ b/diktat-gradle-plugin/src/main/kotlin/org/cqfn/diktat/plugin/gradle/DiktatJavaExecTaskBase.kt
@@ -68,10 +68,10 @@ open class DiktatJavaExecTaskBase @Inject constructor(
                 }
                 .files
                 .forEach {
-                    add("\"${project.trimRootDir(it.path)}\"")
+                    add(it.path)
                 }
             diktatExtension.excludes?.files?.forEach {
-                add("\"!${project.trimRootDir(it.path)}\"")
+                add(it.path)
             }
         }
         logger.debug("Setting JavaExec args to $args")
@@ -124,10 +124,3 @@ fun Project.registerDiktatFixTask(diktatExtension: DiktatExtension, diktatConfig
             DIKTAT_FIX_TASK, DiktatJavaExecTaskBase::class.java, gradle.gradleVersion,
             diktatExtension, diktatConfiguration, listOf("-F ")
         )
-
-private fun Project.trimRootDir(path: String) = if (path.startsWith(rootDir.absolutePath)) {
-    path.drop(rootDir.absolutePath.length)
-} else {
-    path
-}
-    .trim(File.separatorChar)

--- a/diktat-gradle-plugin/src/test/kotlin/org/cqfn/diktat/plugin/gradle/DiktatGradlePluginFunctionalTest.kt
+++ b/diktat-gradle-plugin/src/test/kotlin/org/cqfn/diktat/plugin/gradle/DiktatGradlePluginFunctionalTest.kt
@@ -29,13 +29,19 @@ class DiktatGradlePluginFunctionalTest {
         val result = GradleRunner.create()
             .withProjectDir(testProjectDir.root)
             .withArguments(DIKTAT_CHECK_TASK)
-            .buildAndFail()
+            .forwardOutput()
+            .runCatching {
+                buildAndFail()
+            }
 
-        val diktatCheckBuildResult = result.task(":$DIKTAT_CHECK_TASK")
+        Assertions.assertTrue(result.isSuccess) { "Running gradle returned exception ${result.exceptionOrNull()}" }
+
+        val buildResult = result.getOrNull()!!
+        val diktatCheckBuildResult = buildResult.task(":$DIKTAT_CHECK_TASK")
         requireNotNull(diktatCheckBuildResult)
         Assertions.assertEquals(TaskOutcome.FAILED, diktatCheckBuildResult.outcome)
         Assertions.assertTrue(
-            result.output.contains("[HEADER_MISSING_OR_WRONG_COPYRIGHT]")
+            buildResult.output.contains("[HEADER_MISSING_OR_WRONG_COPYRIGHT]")
         )
     }
 }

--- a/diktat-gradle-plugin/src/test/kotlin/org/cqfn/diktat/plugin/gradle/DiktatGradlePluginFunctionalTest.kt
+++ b/diktat-gradle-plugin/src/test/kotlin/org/cqfn/diktat/plugin/gradle/DiktatGradlePluginFunctionalTest.kt
@@ -1,0 +1,41 @@
+package org.cqfn.diktat.plugin.gradle
+
+import org.cqfn.diktat.plugin.gradle.DiktatGradlePlugin.Companion.DIKTAT_CHECK_TASK
+import org.gradle.internal.impldep.org.junit.rules.TemporaryFolder
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.io.File
+
+class DiktatGradlePluginFunctionalTest {
+    private val testProjectDir = TemporaryFolder()
+
+    @BeforeEach
+    fun setUp() {
+        testProjectDir.create()
+        File("../examples/gradle-kotlin-dsl").copyRecursively(testProjectDir.root)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        testProjectDir.delete()
+    }
+
+    @Test
+    fun `should execute diktatCheck on default values`() {
+        val result = GradleRunner.create()
+            .withProjectDir(testProjectDir.root)
+            .withArguments(DIKTAT_CHECK_TASK)
+            .buildAndFail()
+
+        val diktatCheckBuildResult = result.task(":$DIKTAT_CHECK_TASK")
+        requireNotNull(diktatCheckBuildResult)
+        Assertions.assertEquals(TaskOutcome.FAILED, diktatCheckBuildResult.outcome)
+        Assertions.assertTrue(
+            result.output.contains("[HEADER_MISSING_OR_WRONG_COPYRIGHT]")
+        )
+    }
+}

--- a/diktat-gradle-plugin/src/test/kotlin/org/cqfn/diktat/plugin/gradle/DiktatJavaExecTaskTest.kt
+++ b/diktat-gradle-plugin/src/test/kotlin/org/cqfn/diktat/plugin/gradle/DiktatJavaExecTaskTest.kt
@@ -70,6 +70,6 @@ class DiktatJavaExecTaskTest {
         Assertions.assertIterableEquals(expected, task.commandLine)
     }
 
-    private fun combinePathParts(vararg parts: String) = project.projectDir.absolutePath +
-            parts.joinToString(File.separator, prefix = File.separator)
+    private fun combinePathParts(vararg parts: String) =
+            parts.joinToString(File.separator)
 }

--- a/diktat-gradle-plugin/src/test/kotlin/org/cqfn/diktat/plugin/gradle/DiktatJavaExecTaskTest.kt
+++ b/diktat-gradle-plugin/src/test/kotlin/org/cqfn/diktat/plugin/gradle/DiktatJavaExecTaskTest.kt
@@ -19,7 +19,7 @@ class DiktatJavaExecTaskTest {
     @Test
     fun `check command line for various inputs`() {
         assertCommandLineEquals(
-            listOf(null, "\"${combinePathParts("src", "**", "*.kt")}\""),
+            listOf(null, combinePathParts("src", "**", "*.kt")),
             DiktatExtension().apply {
                 inputs = project.files("src/**/*.kt")
             }
@@ -29,7 +29,7 @@ class DiktatJavaExecTaskTest {
     @Test
     fun `check command line in debug mode`() {
         assertCommandLineEquals(
-            listOf(null, "--debug", "\"${combinePathParts("src", "**", "*.kt")}\""),
+            listOf(null, "--debug", combinePathParts("src", "**", "*.kt")),
             DiktatExtension().apply {
                 inputs = project.files("src/**/*.kt")
                 debug = true
@@ -40,8 +40,8 @@ class DiktatJavaExecTaskTest {
     @Test
     fun `check command line with excludes`() {
         assertCommandLineEquals(
-            listOf(null, "\"${combinePathParts("src", "**", "*.kt")}\"",
-                "\"!${combinePathParts("src", "main", "kotlin", "generated")}\""
+            listOf(null, combinePathParts("src", "**", "*.kt"),
+                combinePathParts("src", "main", "kotlin", "generated")
             ),
             DiktatExtension().apply {
                 inputs = project.files("src/**/*.kt")
@@ -70,6 +70,6 @@ class DiktatJavaExecTaskTest {
         Assertions.assertIterableEquals(expected, task.commandLine)
     }
 
-    private fun combinePathParts(vararg parts: String) =
-            parts.joinToString(File.separator)
+    private fun combinePathParts(vararg parts: String) = project.rootDir.absolutePath +
+            parts.joinToString(File.separator, prefix = File.separator)
 }


### PR DESCRIPTION
### What's done:
* Introduced functional tests for diktat-gradle-plugin
* Calculate code coverage for functional tests for diktat-gradle-plugin
* Skip gradle tests when maven is run with `-DskipTests=true`
* Updated gradle to 6.7.1

This pull request closes #627 