### PR TITLE
Improve diff output format in TestComparator

### DIFF
--- a/diktat-test-framework/src/main/kotlin/org/cqfn/diktat/test/framework/processing/FileComparator.kt
+++ b/diktat-test-framework/src/main/kotlin/org/cqfn/diktat/test/framework/processing/FileComparator.kt
@@ -22,8 +22,8 @@ class FileComparator {
         .showInlineDiffs(true)
         .mergeOriginalRevised(true)
         .inlineDiffByWord(false)
-        .oldTag { b -> if (b) "[" else "]" }
-        .newTag { b -> if (b) "<" else ">" }
+        .oldTag { start -> if (start) "[" else "]" }
+        .newTag { start -> if (start) "<" else ">" }
         .build()
 
     constructor(expectedResultFile: File, actualResultList: List<String?>) {


### PR DESCRIPTION
### What's done:
* Added format for ChangeDeltas

This pull request closes #143

Example of the new format:
```
[ERROR] 2020-12-25 17:43:18 Expected result from <Example1Expected.kt> and actual formatted are different.
See difference below (for ChangeDelta [text] indicates removed text, <text> - inserted):
[DeleteDelta, position: 3, lines: [    /** Docs */]]
[InsertDelta, position: 18, lines: [     * @param sub]]
[ChangeDelta, position 19, lines: [     */
 <   >fun String.countSubStringOccurrences(sub: String): Int {]]
[ChangeDelta, position 30, lines: [         <   >this.replace("\\", "/").replace("//", "/")]]
[ChangeDelta, position 39, lines: [           < >y: [  ]Int) = x +]]
```