### PR TITLE
Bugfix. When changing indentation of multiline string, all lines should be changed

### DIFF
--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/files/IndentationRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/files/IndentationRule.kt
@@ -208,7 +208,7 @@ class IndentationRule(private val configRules: List<RulesConfig>) : Rule("indent
                 nextNode.firstChildNode.elementType == STRING_TEMPLATE &&
                 nextNode.firstChildNode.text.startsWith("\"\"\"") &&
                 nextNode.findChildByType(CALL_EXPRESSION)?.text?.let {
-                            it == "trimIndent()" ||
+                    it == "trimIndent()" ||
                             it == "trimMargin()"
                 } == true) {
             fixStringLiteral(whiteSpace, expectedIndent)

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/files/IndentationRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/files/IndentationRule.kt
@@ -207,8 +207,9 @@ class IndentationRule(private val configRules: List<RulesConfig>) : Rule("indent
                 nextNode.elementType == DOT_QUALIFIED_EXPRESSION &&
                 nextNode.firstChildNode.elementType == STRING_TEMPLATE &&
                 nextNode.firstChildNode.text.startsWith("\"\"\"") &&
-                (nextNode.findChildByType(CALL_EXPRESSION)?.text?.contentEquals("trimIndent()") == true ||
-                nextNode.findChildByType(CALL_EXPRESSION)?.text?.contentEquals("trimMargin()") == true)) {
+                nextNode.findChildByType(CALL_EXPRESSION)?.text?.let {
+                    it == "trimIndent()" ||
+                    it == "trimMargin()" } == true) {
             fixStringLiteral(whiteSpace, expectedIndent)
         }
     }

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/files/IndentationRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/files/IndentationRule.kt
@@ -212,10 +212,10 @@ class IndentationRule(private val configRules: List<RulesConfig>) : Rule("indent
         }
         (templateEntries.last().firstChildNode as LeafPsiElement)
             .rawReplaceWithText(" ".repeat(expectedIndent) + templateEntries
-                    .last()
-                    .firstChildNode
-                    .text
-                    .trim())
+                .last()
+                .firstChildNode
+                .text
+                .trim())
     }
 
     private fun ASTNode.getExceptionalIndentInitiator() = treeParent.let { parent ->

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/files/IndentationRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/files/IndentationRule.kt
@@ -208,8 +208,9 @@ class IndentationRule(private val configRules: List<RulesConfig>) : Rule("indent
                 nextNode.firstChildNode.elementType == STRING_TEMPLATE &&
                 nextNode.firstChildNode.text.startsWith("\"\"\"") &&
                 nextNode.findChildByType(CALL_EXPRESSION)?.text?.let {
-                    it == "trimIndent()" ||
-                    it == "trimMargin()" } == true) {
+                            it == "trimIndent()" ||
+                            it == "trimMargin()"
+                } == true) {
             fixStringLiteral(whiteSpace, expectedIndent)
         }
     }

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/files/IndentationRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/files/IndentationRule.kt
@@ -8,6 +8,7 @@ import org.cqfn.diktat.common.config.rules.RulesConfig
 import org.cqfn.diktat.common.config.rules.getRuleConfig
 import org.cqfn.diktat.ruleset.constants.EmitType
 import org.cqfn.diktat.ruleset.constants.Warnings.WRONG_INDENTATION
+import org.cqfn.diktat.ruleset.utils.getAllChildrenWithType
 import org.cqfn.diktat.ruleset.utils.getAllLeafsWithSpecificType
 import org.cqfn.diktat.ruleset.utils.getFilePath
 import org.cqfn.diktat.ruleset.utils.indentBy
@@ -41,7 +42,6 @@ import com.pinterest.ktlint.core.ast.ElementType.STRING_TEMPLATE
 import com.pinterest.ktlint.core.ast.ElementType.THEN
 import com.pinterest.ktlint.core.ast.ElementType.WHITE_SPACE
 import com.pinterest.ktlint.core.ast.visit
-import org.cqfn.diktat.ruleset.utils.getAllChildrenWithType
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
@@ -211,11 +211,11 @@ class IndentationRule(private val configRules: List<RulesConfig>) : Rule("indent
             }
         }
         (templateEntries.last().firstChildNode as LeafPsiElement)
-                .rawReplaceWithText(" ".repeat(expectedIndent) + templateEntries
-                        .last()
-                        .firstChildNode
-                        .text
-                        .trim())
+            .rawReplaceWithText(" ".repeat(expectedIndent) + templateEntries
+                    .last()
+                    .firstChildNode
+                    .text
+                    .trim())
     }
 
     private fun ASTNode.getExceptionalIndentInitiator() = treeParent.let { parent ->

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/smoke/DiktatSmokeTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/smoke/DiktatSmokeTest.kt
@@ -97,6 +97,12 @@ class DiktatSmokeTest : FixTestBase("test/smoke/src/main/kotlin",
 
     @Test
     @Tag("DiktatRuleSetProvider")
+    fun `smoke test #6`() {
+        fixAndCompare("Example6Expected.kt", "Example6Test.kt")
+    }
+
+    @Test
+    @Tag("DiktatRuleSetProvider")
     fun `smoke test #5`() {
         overrideRulesConfig(emptyList(),
             mapOf(

--- a/diktat-rules/src/test/resources/test/smoke/src/main/kotlin/Example6Expected.kt
+++ b/diktat-rules/src/test/resources/test/smoke/src/main/kotlin/Example6Expected.kt
@@ -5,5 +5,16 @@ val foo =
             some
             cool
             text
+        """.trimIndent()
+
+val bar =
         """
+            | some
+            | text
+        """.trimMargin()
+
+val text =
+        """
+       x 
+    """
 

--- a/diktat-rules/src/test/resources/test/smoke/src/main/kotlin/Example6Expected.kt
+++ b/diktat-rules/src/test/resources/test/smoke/src/main/kotlin/Example6Expected.kt
@@ -1,0 +1,9 @@
+package org.cqfn.diktat
+
+val foo =
+        """
+            some
+            cool
+            text
+        """
+

--- a/diktat-rules/src/test/resources/test/smoke/src/main/kotlin/Example6Test.kt
+++ b/diktat-rules/src/test/resources/test/smoke/src/main/kotlin/Example6Test.kt
@@ -1,0 +1,9 @@
+package org.cqfn.diktat
+
+val foo =
+    """
+        some
+        cool
+        text
+    """
+

--- a/diktat-rules/src/test/resources/test/smoke/src/main/kotlin/Example6Test.kt
+++ b/diktat-rules/src/test/resources/test/smoke/src/main/kotlin/Example6Test.kt
@@ -5,5 +5,16 @@ val foo =
         some
         cool
         text
+    """.trimIndent()
+
+val bar =
+    """
+        | some
+        | text
+    """.trimMargin()
+
+val text =
+    """
+       x 
     """
 


### PR DESCRIPTION
### What's done:
  * Fixed bugs

This pull request closes #574 

