### PR TITLE
DataClassesRule shouldn't trigger when no property in constructor

### DIFF
--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/classes/DataClassesRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/classes/DataClassesRule.kt
@@ -65,13 +65,13 @@ class DataClassesRule(private val configRule: List<RulesConfig>) : Rule("data-cl
     @Suppress("UnsafeCallOnNullableType", "FUNCTION_BOOLEAN_PREFIX", "ComplexMethod")
     private fun ASTNode.canBeDataClass(): Boolean {
         val isNotPropertyInClassBody = findChildByType(CLASS_BODY)?.let { (it.psi as KtClassBody).properties.isEmpty() } ?: true
-        val isNotPropertyInConstructor = findChildByType(PRIMARY_CONSTRUCTOR)
+        val hasPropertyInConstructor  = findChildByType(PRIMARY_CONSTRUCTOR)
             ?.let { constructor ->
                 (constructor.psi as KtPrimaryConstructor)
                     .valueParameters
                     .run { isNotEmpty() && all { it.hasValOrVar() } }
             } ?: false
-        if (isNotPropertyInClassBody && !isNotPropertyInConstructor) {
+        if (isNotPropertyInClassBody && !hasPropertyInConstructor) {
             return false
         }
         val classBody = getFirstChildWithType(CLASS_BODY)

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/classes/DataClassesRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/classes/DataClassesRule.kt
@@ -73,7 +73,7 @@ class DataClassesRule(private val configRule: List<RulesConfig>) : Rule("data-cl
                 .none { it.elementType in badModifiers } &&
                     classBody?.getAllChildrenWithType(FUN)
                         ?.isEmpty()
-                ?: false &&
+                        ?: false &&
                     getFirstChildWithType(SUPER_TYPE_LIST) == null
         }
         return classBody?.getAllChildrenWithType(FUN)?.isEmpty() ?: false &&

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/classes/DataClassesRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/classes/DataClassesRule.kt
@@ -63,23 +63,24 @@ class DataClassesRule(private val configRule: List<RulesConfig>) : Rule("data-cl
 
     @Suppress("UnsafeCallOnNullableType", "FUNCTION_BOOLEAN_PREFIX")
     private fun ASTNode.canBeDataClass(): Boolean {
-        if (findChildByType(PRIMARY_CONSTRUCTOR)?.let { constructor -> (constructor.psi as KtPrimaryConstructor).valueParameters.none { it.hasValOrVar() } } == true)
+        if (findChildByType(PRIMARY_CONSTRUCTOR)?.let { constructor -> (constructor.psi as KtPrimaryConstructor).valueParameters.none { it.hasValOrVar() } } == true) {
             return false
+        }
         val classBody = getFirstChildWithType(CLASS_BODY)
         if (hasChildOfType(MODIFIER_LIST)) {
             val list = getFirstChildWithType(MODIFIER_LIST)!!
             return list.getChildren(null)
-                    .none { it.elementType in badModifiers } &&
+                .none { it.elementType in badModifiers } &&
                     classBody?.getAllChildrenWithType(FUN)
-                            ?.isEmpty()
-                    ?: false &&
+                        ?.isEmpty()
+                ?: false &&
                     getFirstChildWithType(SUPER_TYPE_LIST) == null
         }
         return classBody?.getAllChildrenWithType(FUN)?.isEmpty() ?: false &&
                 getFirstChildWithType(SUPER_TYPE_LIST) == null &&
                 // if there is any prop with logic in accessor then don't recommend to convert class to data class
                 classBody?.let(::areGoodProps)
-                ?: true
+                    ?: true
     }
 
     /**
@@ -107,9 +108,9 @@ class DataClassesRule(private val configRule: List<RulesConfig>) : Rule("data-cl
                 val block = it.getFirstChildWithType(BLOCK)!!
 
                 return block
-                        .getChildren(null)
-                        .filter { expr -> expr.psi is KtExpression }
-                        .count() <= 1
+                    .getChildren(null)
+                    .filter { expr -> expr.psi is KtExpression }
+                    .count() <= 1
             }
         }
 

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/classes/DataClassesRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/classes/DataClassesRule.kt
@@ -65,7 +65,7 @@ class DataClassesRule(private val configRule: List<RulesConfig>) : Rule("data-cl
     @Suppress("UnsafeCallOnNullableType", "FUNCTION_BOOLEAN_PREFIX", "ComplexMethod")
     private fun ASTNode.canBeDataClass(): Boolean {
         val isNotPropertyInClassBody = findChildByType(CLASS_BODY)?.let { (it.psi as KtClassBody).properties.isEmpty() } ?: true
-        val hasPropertyInConstructor  = findChildByType(PRIMARY_CONSTRUCTOR)
+        val hasPropertyInConstructor = findChildByType(PRIMARY_CONSTRUCTOR)
             ?.let { constructor ->
                 (constructor.psi as KtPrimaryConstructor)
                     .valueParameters

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/classes/DataClassesRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/classes/DataClassesRule.kt
@@ -62,16 +62,18 @@ class DataClassesRule(private val configRule: List<RulesConfig>) : Rule("data-cl
         USE_DATA_CLASS.warn(configRule, emitWarn, isFixMode, "${(node.psi as KtClass).name}", node.startOffset, node)
     }
 
-    @Suppress("UnsafeCallOnNullableType", "FUNCTION_BOOLEAN_PREFIX")
+    @Suppress("UnsafeCallOnNullableType", "FUNCTION_BOOLEAN_PREFIX", "ComplexMethod")
     private fun ASTNode.canBeDataClass(): Boolean {
         val isNotPropertyInClassBody = findChildByType(CLASS_BODY)?.let { (it.psi as KtClassBody).properties.isEmpty() } ?: true
         val isNotPropertyInConstructor = findChildByType(PRIMARY_CONSTRUCTOR)
-            ?.let { constructor -> (constructor.psi as KtPrimaryConstructor)
-                .valueParameters
-                .run { isNotEmpty() && all { it.hasValOrVar() } }
+            ?.let { constructor ->
+                (constructor.psi as KtPrimaryConstructor)
+                    .valueParameters
+                    .run { isNotEmpty() && all { it.hasValOrVar() } }
             } ?: false
-        if (isNotPropertyInClassBody && !isNotPropertyInConstructor)
+        if (isNotPropertyInClassBody && !isNotPropertyInConstructor) {
             return false
+        }
         val classBody = getFirstChildWithType(CLASS_BODY)
         if (hasChildOfType(MODIFIER_LIST)) {
             val list = getFirstChildWithType(MODIFIER_LIST)!!

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter6/DataClassesRuleWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter6/DataClassesRuleWarnTest.kt
@@ -96,4 +96,17 @@ class DataClassesRuleWarnTest : LintTestBase(::DataClassesRule) {
                 """.trimMargin()
         )
     }
+
+    @Test
+    @Tag(USE_DATA_CLASS)
+    fun `should not trigger on classes with no property in constructor`() {
+        lintMethod(
+            """
+                    |class B(map: Map<Int,Int>) {}
+                    |
+                    |class A(val map: Map<Int, Int>) {}
+                """.trimMargin(),
+            LintError(3, 1, ruleId, "${Warnings.USE_DATA_CLASS.warnText()} A")
+        )
+    }
 }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter6/DataClassesRuleWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter6/DataClassesRuleWarnTest.kt
@@ -104,9 +104,48 @@ class DataClassesRuleWarnTest : LintTestBase(::DataClassesRule) {
             """
                     |class B(map: Map<Int,Int>) {}
                     |
+                    |class Ab(val map: Map<Int, Int>, map: Map<Int, Int>) {}
+                    |
                     |class A(val map: Map<Int, Int>) {}
+                    |
                 """.trimMargin(),
-            LintError(3, 1, ruleId, "${Warnings.USE_DATA_CLASS.warnText()} A")
+            LintError(5, 1, ruleId, "${Warnings.USE_DATA_CLASS.warnText()} A")
+        )
+    }
+
+    @Test
+    @Tag(USE_DATA_CLASS)
+    fun `should not trigger on empty class`() {
+        lintMethod(
+            """
+                    |class B() {}
+                    |
+                    |class Ab{}
+                    |
+                """.trimMargin()
+        )
+    }
+
+    @Test
+    @Tag(USE_DATA_CLASS)
+    fun `should trigger on class without constructor but with property`() {
+        lintMethod(
+            """
+                    |class B() {
+                    |   val q = 10
+                    |}
+                    |
+                    |class Ab {
+                    |   val qw = 10 
+                    |}
+                    |
+                    |class Ba {
+                    |   val q = 10
+                    |   fun foo() = 10
+                    |}
+                """.trimMargin(),
+            LintError(1, 1, ruleId, "${Warnings.USE_DATA_CLASS.warnText()} B"),
+            LintError(5, 1, ruleId, "${Warnings.USE_DATA_CLASS.warnText()} Ab")
         )
     }
 }


### PR DESCRIPTION
### What's done:
   * [x] Fixed bug
   * [x] Added test
closes #666 