### PR TITLE
Years in copyright examples updated to 2021

### DIFF
--- a/diktat-rules/src/main/resources/diktat-analysis-huawei.yml
+++ b/diktat-rules/src/main/resources/diktat-analysis-huawei.yml
@@ -126,7 +126,7 @@
   enabled: true
   configuration:
     isCopyrightMandatory: true
-    copyrightText: ' Copyright (c) Huawei Technologies Co., Ltd. 2012-2020. All rights reserved.'
+    copyrightText: ' Copyright (c) Huawei Technologies Co., Ltd. 2012-2021. All rights reserved.'
 # Checks that header kdoc is located before package directive
 - name: HEADER_NOT_BEFORE_PACKAGE
   enabled: true

--- a/diktat-rules/src/main/resources/diktat-analysis.yml
+++ b/diktat-rules/src/main/resources/diktat-analysis.yml
@@ -125,7 +125,7 @@
   enabled: true
   configuration:
     isCopyrightMandatory: true
-    copyrightText: 'Copyright (c) Your Company Name Here. 2010-2020'
+    copyrightText: 'Copyright (c) Your Company Name Here. 2010-2021'
 # Checks that header kdoc is located before package directive
 - name: HEADER_NOT_BEFORE_PACKAGE
   enabled: true

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter2/HeaderCommentRuleFixTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter2/HeaderCommentRuleFixTest.kt
@@ -11,6 +11,7 @@ import generated.WarningNames.WRONG_COPYRIGHT_YEAR
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Tags
 import org.junit.jupiter.api.Test
+import java.time.LocalDate
 
 class HeaderCommentRuleFixTest : FixTestBase(
     "test/paragraph2/header",
@@ -19,7 +20,7 @@ class HeaderCommentRuleFixTest : FixTestBase(
         RulesConfig("HEADER_MISSING_OR_WRONG_COPYRIGHT", true,
             mapOf(
                 "isCopyrightMandatory" to "true",
-                "copyrightText" to "Copyright (c) Huawei Technologies Co., Ltd. 2020-2020. All rights reserved.")
+                "copyrightText" to "Copyright (c) Huawei Technologies Co., Ltd. 2020-${LocalDate.now().year}. All rights reserved.")
         ),
         RulesConfig("HEADER_WRONG_FORMAT", true, emptyMap())
     )
@@ -36,6 +37,9 @@ class HeaderCommentRuleFixTest : FixTestBase(
         fixAndCompare("AutoCopyrightExpected.kt", "AutoCopyrightTest.kt")
     }
 
+    /**
+     * Fixme there shouldn't be an additional blank line after copyright
+     */
     @Test
     @Tag(WarningNames.HEADER_NOT_BEFORE_PACKAGE)
     fun `header KDoc should be moved before package`() {
@@ -74,7 +78,7 @@ class HeaderCommentRuleFixTest : FixTestBase(
             listOf(RulesConfig(HEADER_MISSING_OR_WRONG_COPYRIGHT.name, true, mapOf(
                 "isCopyrightMandatory" to "true",
                 "copyrightText" to """
-                |    Copyright 2018-2020 John Doe.
+                |    Copyright 2018-${LocalDate.now().year} John Doe.
                 |
                 |    Licensed under the Apache License, Version 2.0 (the "License");
                 |    you may not use this file except in compliance with the License.

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter2/HeaderCommentRuleTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter2/HeaderCommentRuleTest.kt
@@ -35,11 +35,11 @@ class HeaderCommentRuleTest : LintTestBase(::HeaderCommentRule) {
     )
     private val rulesConfigListYear: List<RulesConfig> = listOf(
         RulesConfig("HEADER_MISSING_OR_WRONG_COPYRIGHT", true,
-            mapOf("copyrightText" to "Copyright (c) 2020 My Company, Ltd. All rights reserved."))
+            mapOf("copyrightText" to "Copyright (c) $curYear My Company, Ltd. All rights reserved."))
     )
     private val rulesConfigListCn: List<RulesConfig> = listOf(
         RulesConfig("HEADER_MISSING_OR_WRONG_COPYRIGHT", true,
-            mapOf("copyrightText" to "版权所有 (c) 华为技术有限公司 2012-2020"))
+            mapOf("copyrightText" to "版权所有 (c) 华为技术有限公司 2012-$curYear"))
     )
     private val curYearCopyright = "Copyright (c) My Company, Ltd. 2012-$curYear. All rights reserved."
     private val copyrightBlock = """
@@ -75,7 +75,7 @@ class HeaderCommentRuleTest : LintTestBase(::HeaderCommentRule) {
         lintMethod(
             """
                 /*
-                 * 版权所有 (c) 华为技术有限公司 2012-2020
+                 * 版权所有 (c) 华为技术有限公司 2012-$curYear
                  */
                 /**
                  * Very useful description, why this file has two classes
@@ -191,7 +191,7 @@ class HeaderCommentRuleTest : LintTestBase(::HeaderCommentRule) {
         lintMethod(
             """
                 /*
-                 * Copyright (c) 2020 My Company, Ltd. All rights reserved.
+                 * Copyright (c) $curYear My Company, Ltd. All rights reserved.
                  */
                 /**
                  * Very useful description, why this file has two classes

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/smoke/DiktatSmokeTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/smoke/DiktatSmokeTest.kt
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 
 import kotlinx.serialization.encodeToString
+import java.time.LocalDate
 
 typealias ruleToConfig = Map<Warnings, Map<String, String>>
 
@@ -110,7 +111,7 @@ class DiktatSmokeTest : FixTestBase("test/smoke/src/main/kotlin",
             mapOf(
                 Warnings.HEADER_MISSING_OR_WRONG_COPYRIGHT to mapOf(
                     "isCopyrightMandatory" to "true",
-                    "copyrightText" to """|Copyright 2018-2020 John Doe.
+                    "copyrightText" to """|Copyright 2018-${LocalDate.now().year} John Doe.
                                     |    Licensed under the Apache License, Version 2.0 (the "License");
                                     |    you may not use this file except in compliance with the License.
                                     |    You may obtain a copy of the License at

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/smoke/DiktatSmokeTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/smoke/DiktatSmokeTest.kt
@@ -4,7 +4,6 @@ import org.cqfn.diktat.common.config.rules.RulesConfig
 import org.cqfn.diktat.common.config.rules.RulesConfigReader
 import org.cqfn.diktat.ruleset.constants.Warnings
 import org.cqfn.diktat.ruleset.constants.Warnings.EMPTY_BLOCK_STRUCTURE_ERROR
-import org.cqfn.diktat.ruleset.constants.Warnings.FILE_NAME_INCORRECT
 import org.cqfn.diktat.ruleset.constants.Warnings.FILE_NAME_MATCH_CLASS
 import org.cqfn.diktat.ruleset.constants.Warnings.HEADER_MISSING_IN_NON_SINGLE_CLASS_FILE
 import org.cqfn.diktat.ruleset.constants.Warnings.KDOC_NO_EMPTY_TAGS
@@ -25,8 +24,9 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 
-import kotlinx.serialization.encodeToString
 import java.time.LocalDate
+
+import kotlinx.serialization.encodeToString
 
 typealias ruleToConfig = Map<Warnings, Map<String, String>>
 

--- a/diktat-rules/src/test/resources/test/paragraph2/header/AutoCopyrightExpected.kt
+++ b/diktat-rules/src/test/resources/test/paragraph2/header/AutoCopyrightExpected.kt
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) Huawei Technologies Co., Ltd. 2020-2020. All rights reserved.
+    Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
 */
 
 package test.paragraph2.header

--- a/diktat-rules/src/test/resources/test/paragraph2/header/CopyrightDifferentYearExpected.kt
+++ b/diktat-rules/src/test/resources/test/paragraph2/header/CopyrightDifferentYearExpected.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) My Company., Ltd. 2012-2020. All rights reserved.
+ * Copyright (c) My Company., Ltd. 2012-2021. All rights reserved.
  */
 /**
  * Lorem ipsum

--- a/diktat-rules/src/test/resources/test/paragraph2/header/MisplacedHeaderKdocAppendedCopyrightExpected.kt
+++ b/diktat-rules/src/test/resources/test/paragraph2/header/MisplacedHeaderKdocAppendedCopyrightExpected.kt
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) Huawei Technologies Co., Ltd. 2020-2020. All rights reserved.
+    Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
 */
 /**
  * Lorem ipsum

--- a/diktat-rules/src/test/resources/test/paragraph2/header/MisplacedHeaderKdocExpected.kt
+++ b/diktat-rules/src/test/resources/test/paragraph2/header/MisplacedHeaderKdocExpected.kt
@@ -1,6 +1,8 @@
 /*
-    Copyright (c) Huawei Technologies Co., Ltd. 2020-2020. All rights reserved.
+    Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
 */
+
+
 /**
  * Lorem ipsum
  * dolor sit amet

--- a/diktat-rules/src/test/resources/test/paragraph2/header/MultilineCopyrightExample.kt
+++ b/diktat-rules/src/test/resources/test/paragraph2/header/MultilineCopyrightExample.kt
@@ -1,5 +1,5 @@
 /*
-    Copyright 2018-2020 John Doe.
+    Copyright 2018-2021 John Doe.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/diktat-rules/src/test/resources/test/paragraph2/header/NewlineAfterHeaderKdocExpected.kt
+++ b/diktat-rules/src/test/resources/test/paragraph2/header/NewlineAfterHeaderKdocExpected.kt
@@ -1,6 +1,7 @@
 /*
-    Copyright (c) Huawei Technologies Co., Ltd. 2020-2020. All rights reserved.
+    Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
 */
+
 /**
  * This is a file used in unit test
  */

--- a/diktat-rules/src/test/resources/test/smoke/src/main/kotlin/Example5Expected.kt
+++ b/diktat-rules/src/test/resources/test/smoke/src/main/kotlin/Example5Expected.kt
@@ -1,5 +1,5 @@
 /*
-    Copyright 2018-2020 John Doe.
+    Copyright 2018-2021 John Doe.
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at

--- a/examples/gradle-groovy-dsl/diktat-analysis.yml
+++ b/examples/gradle-groovy-dsl/diktat-analysis.yml
@@ -81,7 +81,7 @@
   enabled: true
   configuration:
     isCopyrightMandatory: true
-    copyrightText: 'Copyright (c) Your Company Name Here. 2010-2020'
+    copyrightText: 'Copyright (c) Your Company Name Here. 2010-2021'
 - name: HEADER_NOT_BEFORE_PACKAGE
   enabled: true
 - name: HEADER_CONTAINS_DATE_OR_AUTHOR

--- a/examples/gradle-kotlin-dsl-multiproject/diktat-analysis.yml
+++ b/examples/gradle-kotlin-dsl-multiproject/diktat-analysis.yml
@@ -81,7 +81,7 @@
   enabled: true
   configuration:
     isCopyrightMandatory: true
-    copyrightText: 'Copyright (c) Your Company Name Here. 2010-2020'
+    copyrightText: 'Copyright (c) Your Company Name Here. 2010-2021'
 - name: HEADER_NOT_BEFORE_PACKAGE
   enabled: true
 - name: HEADER_CONTAINS_DATE_OR_AUTHOR

--- a/examples/gradle-kotlin-dsl/diktat-analysis.yml
+++ b/examples/gradle-kotlin-dsl/diktat-analysis.yml
@@ -81,7 +81,7 @@
   enabled: true
   configuration:
     isCopyrightMandatory: true
-    copyrightText: 'Copyright (c) Your Company Name Here. 2010-2020'
+    copyrightText: 'Copyright (c) Your Company Name Here. 2010-2021'
 - name: HEADER_NOT_BEFORE_PACKAGE
   enabled: true
 - name: HEADER_CONTAINS_DATE_OR_AUTHOR

--- a/examples/maven/diktat-analysis.yml
+++ b/examples/maven/diktat-analysis.yml
@@ -81,7 +81,7 @@
   enabled: true
   configuration:
     isCopyrightMandatory: true
-    copyrightText: 'Copyright (c) Your Company Name Here. 2010-2020'
+    copyrightText: 'Copyright (c) Your Company Name Here. 2010-2021'
 - name: HEADER_NOT_BEFORE_PACKAGE
   enabled: true
 - name: HEADER_CONTAINS_DATE_OR_AUTHOR


### PR DESCRIPTION
### What's done:
* Years updated

## Fixme
* there are some incorrect fixing cases:
* * Additional blank line is inserted after rearranging comments
* * Sometimes, when year is still not changed, there is an NPE somewhere in year checking logic.
* Overall, it seems there are some cases that need to be fixed and covered with tests in year checking logic.