### PR TITLE
Pass diktat-maven-plugin for maven-itf via maven.config

### DIFF
--- a/diktat-maven-plugin/src/test/kotlin/org/cqfn/diktat/plugin/maven/DiktatMavenPluginIntegrationTest.kt
+++ b/diktat-maven-plugin/src/test/kotlin/org/cqfn/diktat/plugin/maven/DiktatMavenPluginIntegrationTest.kt
@@ -3,7 +3,6 @@ package org.cqfn.diktat.plugin.maven
 import com.soebes.itf.jupiter.extension.MavenGoal
 import com.soebes.itf.jupiter.extension.MavenJupiterExtension
 import com.soebes.itf.jupiter.extension.MavenTest
-import com.soebes.itf.jupiter.extension.SystemProperty
 import com.soebes.itf.jupiter.maven.MavenExecutionResult
 import org.junit.jupiter.api.Assertions
 import java.io.File
@@ -13,14 +12,14 @@ import kotlin.io.path.readText
 /**
  * Integration tests for diktat-maven-plugin. Run against the project from diktat-examples.
  * The whole pipeline is as follows:
- * * For each test case, test data is copied from examples with respect to maven-itf requirements, .mvn/jvm.config is copied too
+ * * For each test case, test data is copied from examples with respect to maven-itf requirements, .mvn/jvm.config and .mvn/maven.config are copied too
  *   Note: for maven itf test name should equal example project's directory name, which we have in pom.xml.
- * * maven-failsafe-plugin launches tests; for each test case a separate maven process is spawned
+ * * maven-failsafe-plugin launches tests; for each test case a separate maven process is spawned. diktat.version is taken from .mvn/maven.config
+ *   and the exact value is written when maven copies resources.
  * * maven execution results are analyzed here; .mvn/jvm.config is used to attach jacoco java agent to every maven process and generate individual execution reports
  */
 @OptIn(ExperimentalPathApi::class)
 @MavenJupiterExtension
-@SystemProperty(value = "diktat.version", content = "0.2.1-SNAPSHOT")  // todo set pluin version for example project properly
 class DiktatMavenPluginIntegrationTest {
     @MavenTest
     @MavenGoal("diktat:check@diktat")

--- a/diktat-maven-plugin/src/test/resources/.mvn/maven.config
+++ b/diktat-maven-plugin/src/test/resources/.mvn/maven.config
@@ -1,0 +1,1 @@
+-Ddiktat.version=${project.version}


### PR DESCRIPTION
### What's done:
* Pass diktat-maven-plugin for maven-itf via maven.config, take value from ${project.version}

This fixes failing release build.