### PR TITLE
Bugfix. diktat-gradle-plugin shouldn't log warning about reporter type

### DIFF
--- a/diktat-gradle-plugin/src/main/kotlin/org/cqfn/diktat/plugin/gradle/DiktatJavaExecTaskBase.kt
+++ b/diktat-gradle-plugin/src/main/kotlin/org/cqfn/diktat/plugin/gradle/DiktatJavaExecTaskBase.kt
@@ -144,7 +144,7 @@ open class DiktatJavaExecTaskBase @Inject constructor(
             }
         } else {
             flag.append("--reporter=plain")
-            log.warn("Unknown reporter was specified. Falling back to plain reporter.")
+            log.debug("Unknown reporter was specified. Falling back to plain reporter.")
         }
     }
 


### PR DESCRIPTION
### What's done:
  * Reduced logging level to debug


This pull request closes #771 
<!-- Briefly describe rule and warnings -->

