### PR TITLE
Use kotlin-multiplatform-diff instead of java-diff-utils

### DIFF
--- a/diktat-test-framework/pom.xml
+++ b/diktat-test-framework/pom.xml
@@ -39,8 +39,8 @@
             <artifactId>slf4j-log4j12</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.java-diff-utils</groupId>
-            <artifactId>java-diff-utils</artifactId>
+            <groupId>io.github.petertrr</groupId>
+            <artifactId>kotlin-multiplatform-diff-jvm</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/diktat-test-framework/src/main/kotlin/org/cqfn/diktat/test/framework/processing/FileComparator.kt
+++ b/diktat-test-framework/src/main/kotlin/org/cqfn/diktat/test/framework/processing/FileComparator.kt
@@ -1,8 +1,8 @@
 package org.cqfn.diktat.test.framework.processing
 
-import com.github.difflib.DiffUtils
-import com.github.difflib.patch.ChangeDelta
-import com.github.difflib.text.DiffRowGenerator
+import io.github.petertrr.diffutils.diff
+import io.github.petertrr.diffutils.patch.ChangeDelta
+import io.github.petertrr.diffutils.text.DiffRowGenerator
 import org.slf4j.LoggerFactory
 
 import java.io.File
@@ -17,7 +17,7 @@ import java.util.stream.Collectors
  */
 class FileComparator {
     private val expectedResultFile: File
-    private val actualResultList: List<String?>
+    private val actualResultList: List<String>
     private val diffGenerator = DiffRowGenerator.create()
         .showInlineDiffs(true)
         .mergeOriginalRevised(true)
@@ -26,7 +26,7 @@ class FileComparator {
         .newTag { start -> if (start) "<" else ">" }
         .build()
 
-    constructor(expectedResultFile: File, actualResultList: List<String?>) {
+    constructor(expectedResultFile: File, actualResultList: List<String>) {
         this.expectedResultFile = expectedResultFile
         this.actualResultList = actualResultList
     }
@@ -47,7 +47,7 @@ class FileComparator {
             if (expect.isEmpty()) {
                 return false
             }
-            val patch = DiffUtils.diff(expect, actualResultList)
+            val patch = diff(expect, actualResultList)
             if (patch.deltas.isEmpty()) {
                 return true
             }

--- a/pom.xml
+++ b/pom.xml
@@ -127,9 +127,9 @@
                 <version>${slf4j.version}</version>
             </dependency>
             <dependency>
-                <groupId>io.github.java-diff-utils</groupId>
-                <artifactId>java-diff-utils</artifactId>
-                <version>4.8</version>
+                <groupId>io.github.petertrr</groupId>
+                <artifactId>kotlin-multiplatform-diff-jvm</artifactId>
+                <version>0.1.0</version>
             </dependency>
             <dependency>
                 <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
### What's done:
* Changed dependency
* Fixed API

kotlin-multiplatform-diff is a pure kotlin port of java-diff-utils