### PR TITLE
Collapse if statements with comments

### DIFF
--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/DiktatRuleSetProvider.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/DiktatRuleSetProvider.kt
@@ -190,6 +190,7 @@ class DiktatRuleSetProvider(private var diktatConfigFile: String = DIKTAT_ANALYS
             ::StringConcatenationRule,
             ::StringTemplateFormatRule,
             ::AccurateCalculationsRule,
+            ::CollapseIfStatementsRule,
             ::LineLength,
             ::RunInScript,
             ::TypeAliasRule,
@@ -207,7 +208,6 @@ class DiktatRuleSetProvider(private var diktatConfigFile: String = DIKTAT_ANALYS
             ::AvoidNestedFunctionsRule,
             ::ExtensionFunctionsSameNameRule,
             ::LambdaLengthRule,
-            ::CollapseIfStatementsRule,
             // formatting: moving blocks, adding line breaks, indentations etc.
             ::BlockStructureBraces,
             ::ConsecutiveSpacesRule,

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/CollapseIfStatementsRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/CollapseIfStatementsRule.kt
@@ -92,6 +92,9 @@ class CollapseIfStatementsRule(configRules: List<RulesConfig>) : DiktatRule(
         // We monitor which types of nodes are followed before and after nested `if`
         // and we allow only a limited number of types to pass through.
         // Otherwise discovered `if` is not nested
+        // We don't expect KDOC in `if-statements`, since it's a bad practise, and such code by meaning of our
+        // code analyzer is invalid
+        // However, if in some case we will hit the KDOC, than we won't collapse statements
         val listOfNodesBeforeNestedIf = parentThenNode.getChildren(null).takeWhile { it.elementType != IF }
         val listOfNodesAfterNestedIf = parentThenNode.getChildren(null).takeLastWhile { it != parentThenNode.findChildByType(IF) }
         val allowedTypes = listOf(LBRACE, WHITE_SPACE, RBRACE, BLOCK_COMMENT, EOL_COMMENT)

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/CollapseIfStatementsRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/CollapseIfStatementsRule.kt
@@ -108,7 +108,7 @@ class CollapseIfStatementsRule(configRules: List<RulesConfig>) : DiktatRule(
             it.elementType == EOL_COMMENT ||
                     it.elementType == BLOCK_COMMENT
         }
-            ?.toList() ?: listOf()
+            ?.toList() ?: emptyList()
     }
 
     private fun collapse(parentNode: ASTNode, nestedNode: ASTNode) {

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/CollapseIfStatementsRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/CollapseIfStatementsRule.kt
@@ -120,7 +120,7 @@ class CollapseIfStatementsRule(configRules: List<RulesConfig>) : DiktatRule(
         // If there are comments before nested if, we will move them into parent condition
         val comments = takeCommentsBeforeNestedIf(parentNode)
         val commentsText = if (comments.isNotEmpty()) {
-            "\n${comments.joinToString("\n") { it.text }}\n"
+            comments.joinToString(prefix = "\n", postfix = "\n", separator = "\n") { it.text }
         } else {
             " "
         }
@@ -165,8 +165,16 @@ class CollapseIfStatementsRule(configRules: List<RulesConfig>) : DiktatRule(
         val nestedContent = (nestedThenNode as KtBlockExpression).children().toMutableList()
         // Remove {, }, and white spaces
         repeat(2) {
-            nestedContent.removeFirst()
-            nestedContent.removeLast()
+            val firstElType = nestedContent.first().elementType
+            if (firstElType == WHITE_SPACE ||
+                    firstElType == LBRACE) {
+                nestedContent.removeFirst()
+            }
+            val lastElType = nestedContent.last().elementType
+            if (lastElType == WHITE_SPACE ||
+                    lastElType == RBRACE) {
+                nestedContent.removeLast()
+            }
         }
         val nestedThenText = nestedContent.joinToString("") { it.text }
         val newNestedNode = KotlinParser().createNode(nestedThenText).treeParent

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/CollapseIfStatementsRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/CollapseIfStatementsRule.kt
@@ -139,9 +139,9 @@ class CollapseIfStatementsRule(configRules: List<RulesConfig>) : DiktatRule(
                 if (nestedCondition?.node?.elementType == BINARY_EXPRESSION &&
                         nestedCondition.node?.findChildByType(OPERATION_REFERENCE)?.text == "||"
                 ) {
-                    "if ($parentConditionText &&$commentsText(${nestedConditionText})) {}"
+                    "if ($parentConditionText &&$commentsText($nestedConditionText)) {}"
                 } else {
-                    "if ($parentConditionText &&$commentsText${nestedConditionText}) {}"
+                    "if ($parentConditionText &&$commentsText$nestedConditionText) {}"
                 }
         val newParentIfNode = KotlinParser().createNode(mergeCondition)
         // Remove THEN block
@@ -155,12 +155,13 @@ class CollapseIfStatementsRule(configRules: List<RulesConfig>) : DiktatRule(
             addAfter = parentNode.children().drop(index + 1).first()
         }
     }
+
     // If condition contains comments, we need additional actions
     // Because of `node.condition` will ignore comments
     private fun extractConditions(node: ASTNode): String {
         val condition = node.getChildren(null)
-            .takeLastWhile { it != node.findChildByType(LPAR)}
-                .takeWhile { it != node.findChildByType(RPAR) }
+            .takeLastWhile { it != node.findChildByType(LPAR) }
+            .takeWhile { it != node.findChildByType(RPAR) }
         return condition.joinToString("") { it.text }
     }
 

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/CollapseIfStatementsRuleWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/CollapseIfStatementsRuleWarnTest.kt
@@ -77,6 +77,24 @@ class CollapseIfStatementsRuleWarnTest : LintTestBase(::CollapseIfStatementsRule
 
     @Test
     @Tag(WarningNames.COLLAPSE_IF_STATEMENTS)
+    fun `eol comment`() {
+        lintMethod(
+            """
+            |fun foo () {
+            |     if (true) {
+            |         // Some comments
+            |         if (true) {
+            |             doSomething()
+            |         }
+            |     }
+            |}
+            """.trimMargin(),
+            LintError(4, 10, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true)
+        )
+    }
+
+    @Test
+    @Tag(WarningNames.COLLAPSE_IF_STATEMENTS)
     fun `comments check`() {
         lintMethod(
             """
@@ -90,8 +108,12 @@ class CollapseIfStatementsRuleWarnTest : LintTestBase(::CollapseIfStatementsRule
             |         */
             |         // Even more comments
             |         if (true) {
+            |             // comment 1
+            |             val a = 5
+            |             // comment 2
             |             doSomething()
             |         }
+            |         // comment 3
             |     }
             |} 
             """.trimMargin(),

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/CollapseIfStatementsRuleWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/CollapseIfStatementsRuleWarnTest.kt
@@ -197,6 +197,61 @@ class CollapseIfStatementsRuleWarnTest : LintTestBase(::CollapseIfStatementsRule
 
     @Test
     @Tag(WarningNames.COLLAPSE_IF_STATEMENTS)
+    fun `comments already in cond`() {
+        lintMethod(
+            """
+            |fun foo () {
+            |     if (/*comment*/ true) {
+            |         if (true) {
+            |             doSomething()
+            |         }
+            |     }
+            |}
+            """.trimMargin(),
+            LintError(3, 10, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true)
+        )
+    }
+
+    @Test
+    @Tag(WarningNames.COLLAPSE_IF_STATEMENTS)
+    fun `comments already in complex cond`() {
+        lintMethod(
+            """
+            |fun foo () {
+            |     if (true && (true || false) /*comment*/) {
+            |         if (true /*comment*/) {
+            |             doSomething()
+            |         }
+            |     }
+            |}
+            """.trimMargin(),
+            LintError(3, 10, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true)
+        )
+    }
+
+    @Test
+    @Tag(WarningNames.COLLAPSE_IF_STATEMENTS)
+    fun `multiline comments already in cond`() {
+        lintMethod(
+            """
+            |fun foo () {
+            |     if (true
+            |     /*comment
+            |     * more comments
+            |     */
+            |     ) {
+            |         if (true /*comment 2*/) {
+            |             doSomething()
+            |         }
+            |     }
+            |}
+            """.trimMargin(),
+            LintError(7, 10, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true)
+        )
+    }
+
+    @Test
+    @Tag(WarningNames.COLLAPSE_IF_STATEMENTS)
     fun `comments in multiple if-statements`() {
         lintMethod(
             """

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/CollapseIfStatementsRuleWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/CollapseIfStatementsRuleWarnTest.kt
@@ -77,6 +77,21 @@ class CollapseIfStatementsRuleWarnTest : LintTestBase(::CollapseIfStatementsRule
 
     @Test
     @Tag(WarningNames.COLLAPSE_IF_STATEMENTS)
+    fun `nested if with incorrect indention`() {
+        lintMethod(
+            """
+            |fun foo () {
+            |     if (true) {
+            |         if (true) {doSomething()}
+            |     }
+            |}
+            """.trimMargin(),
+            LintError(3, 10, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true)
+        )
+    }
+
+    @Test
+    @Tag(WarningNames.COLLAPSE_IF_STATEMENTS)
     fun `eol comment`() {
         lintMethod(
             """

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/CollapseIfStatementsRuleWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/CollapseIfStatementsRuleWarnTest.kt
@@ -82,31 +82,68 @@ class CollapseIfStatementsRuleWarnTest : LintTestBase(::CollapseIfStatementsRule
             """
             |fun foo () {
             |     if (true) {
-            |         // Some comments
+            |         // Some
+            |         // comments
             |         if (true) {
             |             doSomething()
             |         }
             |     }
             |}
             """.trimMargin(),
-            LintError(4, 10, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true)
+            LintError(5, 10, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true)
         )
     }
 
     @Test
     @Tag(WarningNames.COLLAPSE_IF_STATEMENTS)
-    fun `comments check`() {
+    fun `block comment`() {
+        lintMethod(
+            """
+            |fun foo () {
+            |     if (true) {
+            |         /*
+            |          Some comments
+            |         */
+            |         if (true) {
+            |             doSomething()
+            |         }
+            |     }
+            |}
+            """.trimMargin(),
+            LintError(6, 10, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true)
+        )
+    }
+
+    @Test
+    @Tag(WarningNames.COLLAPSE_IF_STATEMENTS)
+    fun `kdoc comment`() {
         lintMethod(
             """
             |fun foo () {
             |     if (true) {
             |         /**
-            |          * Some Comments
-            |          */
-            |         /*
-            |          More comments
+            |          * Some comments
             |         */
-            |         // Even more comments
+            |         if (true) {
+            |             doSomething()
+            |         }
+            |     }
+            |}
+            """.trimMargin()
+        )
+    }
+
+    @Test
+    @Tag(WarningNames.COLLAPSE_IF_STATEMENTS)
+    fun `combine comments`() {
+        lintMethod(
+            """
+            |fun foo () {
+            |     if (true) {
+            |         /*
+            |          Some Comments
+            |         */
+            |         // More comments
             |         if (true) {
             |             // comment 1
             |             val a = 5
@@ -117,7 +154,7 @@ class CollapseIfStatementsRuleWarnTest : LintTestBase(::CollapseIfStatementsRule
             |     }
             |} 
             """.trimMargin(),
-            LintError(10, 10, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true)
+            LintError(7, 10, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true)
         )
     }
 

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/CollapseIfStatementsRuleWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/CollapseIfStatementsRuleWarnTest.kt
@@ -160,6 +160,50 @@ class CollapseIfStatementsRuleWarnTest : LintTestBase(::CollapseIfStatementsRule
 
     @Test
     @Tag(WarningNames.COLLAPSE_IF_STATEMENTS)
+    fun `comments in compound cond`() {
+        lintMethod(
+            """
+            |fun foo() {
+            |     // comment
+            |     if (cond1) {
+            |         /*
+            |          Some comments
+            |         */
+            |         // More comments
+            |         if (cond2 || cond3) {
+            |             doSomething()
+            |         }
+            |     }
+            |}
+            """.trimMargin(),
+            LintError(8, 10, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true)
+        )
+    }
+
+    @Test
+    @Tag(WarningNames.COLLAPSE_IF_STATEMENTS)
+    fun `comments in multiple if-statements`() {
+        lintMethod(
+            """
+            |fun foo() {
+            |     if (cond1) {
+            |         // comment
+            |         if (cond2) {
+            |             // comment 2
+            |             if (cond3) {
+            |                 doSomething()
+            |             }
+            |         }
+            |     }
+            |}
+            """.trimMargin(),
+            LintError(4, 10, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true),
+            LintError(6, 14, ruleId, "${COLLAPSE_IF_STATEMENTS.warnText()} avoid using redundant nested if-statements", true)
+        )
+    }
+
+    @Test
+    @Tag(WarningNames.COLLAPSE_IF_STATEMENTS)
     fun `not nested if`() {
         lintMethod(
             """

--- a/diktat-rules/src/test/resources/test/paragraph3/collapse_if/CollapseIfStatementsExpected.kt
+++ b/diktat-rules/src/test/resources/test/paragraph3/collapse_if/CollapseIfStatementsExpected.kt
@@ -219,3 +219,37 @@ fun foo () {
         doSomething()
     }
 }
+
+fun foo () {
+     if (/*comment*/ true && true) {
+         doSomething()
+     }
+}
+
+fun foo () {
+    if (true /*comment*/ && true) {
+        doSomething()
+    }
+}
+
+fun foo () {
+    if (true && true /*comment*/) {
+        doSomething()
+    }
+}
+
+fun foo () {
+    if (true && (true || false) /*comment*/ && true /*comment*/) {
+        doSomething()
+    }
+}
+
+fun foo () {
+     if (true
+     /*comment
+     * more comments
+     */
+      && true /*comment 2*/) {
+         doSomething()
+     }
+}

--- a/diktat-rules/src/test/resources/test/paragraph3/collapse_if/CollapseIfStatementsExpected.kt
+++ b/diktat-rules/src/test/resources/test/paragraph3/collapse_if/CollapseIfStatementsExpected.kt
@@ -191,3 +191,25 @@ true) {
         doSomething()
     }
 }
+
+fun foo() {
+    // comment
+    if (cond1 &&
+/*
+         Some comments
+        */
+// More comments
+(cond2 || cond3)) {
+        doSomething()
+    }
+}
+
+fun foo() {
+    if (cond1 &&
+// comment
+cond2 &&
+// comment 2
+cond3) {
+        doSomething()
+    }
+}

--- a/diktat-rules/src/test/resources/test/paragraph3/collapse_if/CollapseIfStatementsExpected.kt
+++ b/diktat-rules/src/test/resources/test/paragraph3/collapse_if/CollapseIfStatementsExpected.kt
@@ -89,7 +89,7 @@ fun foo() {
 fun foo() {
     if (cond1 && (cond2 && cond3 || cond4)) {
         firstAction()
-secondAction()
+            secondAction()
     }
 }
 
@@ -130,7 +130,7 @@ fun foo () {
 fun foo() {
     if (cond1 && cond2) {
         firstAction()
-secondAction()
+            secondAction()
     }
     if (cond3) {
         secondAction()
@@ -140,7 +140,7 @@ secondAction()
 fun foo() {
     if (cond1 && (cond2 || cond3)) {
         firstAction()
-secondAction()
+            secondAction()
     }
     if (cond4) {
         secondAction()

--- a/diktat-rules/src/test/resources/test/paragraph3/collapse_if/CollapseIfStatementsExpected.kt
+++ b/diktat-rules/src/test/resources/test/paragraph3/collapse_if/CollapseIfStatementsExpected.kt
@@ -167,3 +167,27 @@ fun foo() {
         val a = 5
     }
 }
+
+fun foo() {
+    if (true &&
+/*
+         Some Comments
+        */
+// More comments
+true) {
+        // comment 1
+            val a = 5
+            // comment 2
+            doSomething()
+        // comment 3
+    }
+}
+
+fun foo() {
+    if (true &&
+// Some
+// comments
+true) {
+        doSomething()
+    }
+}

--- a/diktat-rules/src/test/resources/test/paragraph3/collapse_if/CollapseIfStatementsExpected.kt
+++ b/diktat-rules/src/test/resources/test/paragraph3/collapse_if/CollapseIfStatementsExpected.kt
@@ -213,3 +213,9 @@ cond3) {
         doSomething()
     }
 }
+
+fun foo () {
+    if (true && true) {
+        doSomething()
+    }
+}

--- a/diktat-rules/src/test/resources/test/paragraph3/collapse_if/CollapseIfStatementsTest.kt
+++ b/diktat-rules/src/test/resources/test/paragraph3/collapse_if/CollapseIfStatementsTest.kt
@@ -256,3 +256,47 @@ fun foo () {
         if (true) {doSomething()}
     }
 }
+
+fun foo () {
+     if (/*comment*/ true) {
+         if (true) {
+             doSomething()
+         }
+     }
+}
+
+fun foo () {
+    if (true /*comment*/) {
+        if (true) {
+            doSomething()
+        }
+    }
+}
+
+fun foo () {
+    if (true) {
+        if (true /*comment*/) {
+            doSomething()
+        }
+    }
+}
+
+fun foo () {
+    if (true && (true || false) /*comment*/) {
+        if (true /*comment*/) {
+            doSomething()
+        }
+    }
+}
+
+fun foo () {
+     if (true
+     /*comment
+     * more comments
+     */
+     ) {
+         if (true /*comment 2*/) {
+             doSomething()
+         }
+     }
+}

--- a/diktat-rules/src/test/resources/test/paragraph3/collapse_if/CollapseIfStatementsTest.kt
+++ b/diktat-rules/src/test/resources/test/paragraph3/collapse_if/CollapseIfStatementsTest.kt
@@ -250,3 +250,9 @@ fun foo() {
         }
     }
 }
+
+fun foo () {
+    if (true) {
+        if (true) {doSomething()}
+    }
+}

--- a/diktat-rules/src/test/resources/test/paragraph3/collapse_if/CollapseIfStatementsTest.kt
+++ b/diktat-rules/src/test/resources/test/paragraph3/collapse_if/CollapseIfStatementsTest.kt
@@ -225,3 +225,28 @@ fun foo() {
         }
     }
 }
+
+fun foo() {
+    // comment
+    if (cond1) {
+        /*
+         Some comments
+        */
+        // More comments
+        if (cond2 || cond3) {
+            doSomething()
+        }
+    }
+}
+
+fun foo() {
+    if (cond1) {
+        // comment
+        if (cond2) {
+            // comment 2
+            if (cond3) {
+                doSomething()
+            }
+        }
+    }
+}

--- a/diktat-rules/src/test/resources/test/paragraph3/collapse_if/CollapseIfStatementsTest.kt
+++ b/diktat-rules/src/test/resources/test/paragraph3/collapse_if/CollapseIfStatementsTest.kt
@@ -199,3 +199,29 @@ fun foo() {
         val a = 5
     }
 }
+
+fun foo() {
+    if (true) {
+        /*
+         Some Comments
+        */
+        // More comments
+        if (true) {
+            // comment 1
+            val a = 5
+            // comment 2
+            doSomething()
+        }
+        // comment 3
+    }
+}
+
+fun foo() {
+    if (true) {
+        // Some
+        // comments
+        if (true) {
+            doSomething()
+        }
+    }
+}


### PR DESCRIPTION
### What's done:
* Change collapseThenBlocks function: KtBlockExpression.statements didn't hold comments, now it's fixed
* Monitor, which types of nodes are followed after nested if (more proper way), instead of check, that this if is the last child
* Fix indentions in tests