### PR TITLE
Use github packages for kotlin-maven-plugin-tools

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -117,7 +117,7 @@ jobs:
             [
               { "id": "ossrh", "username": "${{ secrets.SONATYPE_USER }}", "password": "${{ secrets.SONATYPE_PASSWORD }}" },
               { "id": "gpg.passphrase", "passphrase": "${{ secrets.DIKTAT_GPG_PASS }}" },
-              { "id": "kotlin-maven-plugin-tools", "password": "${{ secrets.GITHUB_TOKEN }}" }
+              { "id": "kotlin-maven-plugin-tools", "username": "${{github.actor}}", "password": "${{ secrets.GITHUB_TOKEN }}" }
             ]
       - name: Maven Install
         if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -109,10 +109,21 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-build-
 
+      # Todo: remove; this is for testing purposes
+      - name: Create settings.xml
+        uses: whelk-io/maven-settings-xml-action@v15
+        with:
+          servers: |
+            [
+              { "id": "ossrh", "username": "${{ secrets.SONATYPE_USER }}", "password": "${{ secrets.SONATYPE_PASSWORD }}" },
+              { "id": "gpg.passphrase", "passphrase": "${{ secrets.DIKTAT_GPG_PASS }}" },
+              { "id": "github", "passphrase": "${{ secrets.GITHUB_TOKEN }}" }
+            ]
       - name: Maven Install
         if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
         run: |
           mvn -B clean install
+          mvn -B install -Prelease --pl diktat-maven-plugin
         shell: bash
 
       - name: Maven Install on windows

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -117,19 +117,19 @@ jobs:
             [
               { "id": "ossrh", "username": "${{ secrets.SONATYPE_USER }}", "password": "${{ secrets.SONATYPE_PASSWORD }}" },
               { "id": "gpg.passphrase", "passphrase": "${{ secrets.DIKTAT_GPG_PASS }}" },
-              { "id": "github", "passphrase": "${{ secrets.GITHUB_TOKEN }}" }
+              { "id": "kotlin-maven-plugin-tools", "passphrase": "${{ secrets.GITHUB_TOKEN }}" }
             ]
       - name: Maven Install
         if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
         run: |
-          mvn -B clean install
+          mvn -B -T1C clean install
           mvn -B install -Prelease --pl diktat-maven-plugin
         shell: bash
 
       - name: Maven Install on windows
         if: runner.os == 'Windows'
         run: |
-          mvn -B clean install
+          mvn -B -T1C clean install
         shell: cmd
 
       - name: Upload gradle reports

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -109,21 +109,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-build-
 
-      # Todo: remove; this is for testing purposes
-      - name: Create settings.xml
-        uses: whelk-io/maven-settings-xml-action@v15
-        with:
-          servers: |
-            [
-              { "id": "ossrh", "username": "${{ secrets.SONATYPE_USER }}", "password": "${{ secrets.SONATYPE_PASSWORD }}" },
-              { "id": "gpg.passphrase", "passphrase": "${{ secrets.DIKTAT_GPG_PASS }}" },
-              { "id": "kotlin-maven-plugin-tools", "username": "${{github.actor}}", "password": "${{ secrets.GITHUB_TOKEN }}" }
-            ]
       - name: Maven Install
         if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
         run: |
           mvn -B -T1C clean install
-          mvn -B install -Prelease --pl diktat-maven-plugin
         shell: bash
 
       - name: Maven Install on windows

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -117,7 +117,7 @@ jobs:
             [
               { "id": "ossrh", "username": "${{ secrets.SONATYPE_USER }}", "password": "${{ secrets.SONATYPE_PASSWORD }}" },
               { "id": "gpg.passphrase", "passphrase": "${{ secrets.DIKTAT_GPG_PASS }}" },
-              { "id": "kotlin-maven-plugin-tools", "passphrase": "${{ secrets.GITHUB_TOKEN }}" }
+              { "id": "kotlin-maven-plugin-tools", "password": "${{ secrets.GITHUB_TOKEN }}" }
             ]
       - name: Maven Install
         if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
             [
               { "id": "ossrh", "username": "${{ secrets.SONATYPE_USER }}", "password": "${{ secrets.SONATYPE_PASSWORD }}" },
               { "id": "gpg.passphrase", "passphrase": "${{ secrets.DIKTAT_GPG_PASS }}" },
-              { "id": "kotlin-maven-plugin-tools", "passphrase": "${{ secrets.GITHUB_TOKEN }}" }
+              { "id": "kotlin-maven-plugin-tools", "password": "${{ secrets.GITHUB_TOKEN }}" }
             ]
       - name: Deploy artifacts
         run: mvn -B clean deploy -Prelease --projects '!diktat-ruleset'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,12 @@ jobs:
       - name: Create settings.xml
         uses: whelk-io/maven-settings-xml-action@v15
         with:
-          servers: '[{ "id": "ossrh", "username": "${{ secrets.SONATYPE_USER }}", "password": "${{ secrets.SONATYPE_PASSWORD }}" }, { "id": "gpg.passphrase", "passphrase": "${{ secrets.DIKTAT_GPG_PASS }}" }]'
+          servers: |
+            [
+              { "id": "ossrh", "username": "${{ secrets.SONATYPE_USER }}", "password": "${{ secrets.SONATYPE_PASSWORD }}" },
+              { "id": "gpg.passphrase", "passphrase": "${{ secrets.DIKTAT_GPG_PASS }}" },
+              { "id": "github", "passphrase": "${{ secrets.GITHUB_TOKEN }}" }
+            ]
       - name: Deploy artifacts
         run: mvn -B clean deploy -Prelease --projects '!diktat-ruleset'
       - name: Build diktat.jar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
             [
               { "id": "ossrh", "username": "${{ secrets.SONATYPE_USER }}", "password": "${{ secrets.SONATYPE_PASSWORD }}" },
               { "id": "gpg.passphrase", "passphrase": "${{ secrets.DIKTAT_GPG_PASS }}" },
-              { "id": "kotlin-maven-plugin-tools", "password": "${{ secrets.GITHUB_TOKEN }}" }
+              { "id": "kotlin-maven-plugin-tools", "username": "${{github.actor}}", "password": "${{ secrets.GITHUB_TOKEN }}" }
             ]
       - name: Deploy artifacts
         run: mvn -B clean deploy -Prelease --projects '!diktat-ruleset'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
             [
               { "id": "ossrh", "username": "${{ secrets.SONATYPE_USER }}", "password": "${{ secrets.SONATYPE_PASSWORD }}" },
               { "id": "gpg.passphrase", "passphrase": "${{ secrets.DIKTAT_GPG_PASS }}" },
-              { "id": "github", "passphrase": "${{ secrets.GITHUB_TOKEN }}" }
+              { "id": "kotlin-maven-plugin-tools", "passphrase": "${{ secrets.GITHUB_TOKEN }}" }
             ]
       - name: Deploy artifacts
         run: mvn -B clean deploy -Prelease --projects '!diktat-ruleset'

--- a/diktat-maven-plugin/README.md
+++ b/diktat-maven-plugin/README.md
@@ -1,0 +1,5 @@
+## Building
+To generate plugin descriptor using data from KDocs, we use [kotlin-maven-plugin-tools]().
+It is activated only in release profile (`-Prelease`) and shouldn't be a problem for local development.
+Still, this plugin is only available in github packages and needs authentication via `settings.xml`.
+If you need to run it locally, see [release.yml](../.github/workflows/release.yml) as an example.

--- a/diktat-maven-plugin/README.md
+++ b/diktat-maven-plugin/README.md
@@ -1,5 +1,7 @@
 ## Building
-To generate plugin descriptor using data from KDocs, we use [kotlin-maven-plugin-tools]().
-It is activated only in release profile (`-Prelease`) and shouldn't be a problem for local development.
-Still, this plugin is only available in github packages and needs authentication via `settings.xml`.
-If you need to run it locally, see [release.yml](../.github/workflows/release.yml) as an example.
+To build and test the plugin, use regular maven commands.
+
+To generate plugin descriptor using data from KDocs, we use [kotlin-maven-plugin-tools](https://github.com/gantsign/kotlin-maven-plugin-tools).
+This plugin is only available in github packages, which require authentication via `settings.xml`. However,
+this plugin is activated only in release profile (`-Prelease`) and package repository doesn't require any authentication for local development.
+If you need to run it locally, see [release.yml](../.github/workflows/release.yml) as an example of adding an entry to `settings.xml` `servers` section.

--- a/diktat-maven-plugin/pom.xml
+++ b/diktat-maven-plugin/pom.xml
@@ -260,9 +260,9 @@
             <id>release</id>
             <pluginRepositories>
                 <pluginRepository>
-                    <id>bintray-gantsign-maven</id>
-                    <name>bintray-plugins</name>
-                    <url>https://dl.bintray.com/gantsign/maven</url>
+                    <id>kotlin-maven-plugin-tools</id>
+                    <name>GitHub Packages</name>
+                    <url>https://maven.pkg.github.com/gantsign/kotlin-maven-plugin-tools</url>
                     <snapshots>
                         <enabled>false</enabled>
                     </snapshots>
@@ -299,7 +299,7 @@
                             <dependency>
                                 <groupId>com.github.gantsign.maven.plugin-tools</groupId>
                                 <artifactId>kotlin-maven-plugin-tools</artifactId>
-                                <version>0.9.25</version>
+                                <version>0.9.26</version>
                             </dependency>
                         </dependencies>
                     </plugin>


### PR DESCRIPTION
### What's done:
* Changed pluginRepositories in pom.xml
* Update CI workflows
* Added notes in README.md

Background: this plugin has been available only in bintray, which will be shut down soon. As discussed in https://github.com/gantsign/kotlin-maven-plugin-tools/issues/293, the plugin is for now moved to github packages, because there are some difficulties to move to Maven Cenral.