### PR TITLE
Remove jcenter from the list of dependency repositories

### DIFF
--- a/diktat-gradle-plugin/build.gradle.kts
+++ b/diktat-gradle-plugin/build.gradle.kts
@@ -16,7 +16,6 @@ repositories {
     }
     mavenLocal()  // to use snapshot diktat
     mavenCentral()
-    jcenter()
 }
 
 // default value is needed for correct gradle loading in IDEA; actual value from maven is used during build

--- a/diktat-rules/src/test/resources/test/smoke/build.gradle_.kts
+++ b/diktat-rules/src/test/resources/test/smoke/build.gradle_.kts
@@ -6,7 +6,6 @@ plugins {
 }
 
 repositories {
-    jcenter()
     mavenCentral()
     maven { url = uri("https://example.com") }
 }

--- a/info/buildSrc/build.gradle.kts
+++ b/info/buildSrc/build.gradle.kts
@@ -3,7 +3,6 @@ plugins {
 }
 
 repositories {
-    jcenter()
     mavenLocal()
     flatDir {
         dirs(

--- a/pom.xml
+++ b/pom.xml
@@ -156,18 +156,6 @@
 
     </dependencyManagement>
 
-    <pluginRepositories>
-        <pluginRepository>
-            <!-- for dokka and probably other kotlin-related artifacts -->
-            <id>jcenter</id>
-            <name>JCenter</name>
-            <url>https://jcenter.bintray.com/</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-        </pluginRepository>
-    </pluginRepositories>
-
     <build>
         <pluginManagement>
             <plugins>


### PR DESCRIPTION
### What's done:
* Removed jcenter from pom.xml and build.gradle.kts

jcenter will be shut down soon; it was originally introduced in diktat for using dokka, but is probably no more needed