### PR TITLE
Bugfix. Top-level constants should not be considered magic number

### DIFF
--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/MagicNumberRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/MagicNumberRule.kt
@@ -8,6 +8,7 @@ import org.cqfn.diktat.ruleset.rules.DiktatRule
 import org.cqfn.diktat.ruleset.utils.*
 
 import com.pinterest.ktlint.core.ast.ElementType.BINARY_EXPRESSION
+import com.pinterest.ktlint.core.ast.ElementType.CONST_KEYWORD
 import com.pinterest.ktlint.core.ast.ElementType.ENUM_ENTRY
 import com.pinterest.ktlint.core.ast.ElementType.FLOAT_CONSTANT
 import com.pinterest.ktlint.core.ast.ElementType.FUN
@@ -37,9 +38,17 @@ class MagicNumberRule(configRules: List<RulesConfig>) : DiktatRule(
         )
     }
     override fun logic(node: ASTNode) {
-        if (node.elementType == INTEGER_CONSTANT || node.elementType == FLOAT_CONSTANT) {
+        if ((node.elementType == INTEGER_CONSTANT || node.elementType == FLOAT_CONSTANT)
+                && !isTopLevelDeclarationConstant(node)) {
             checkNumber(node, configuration)
         }
+    }
+
+    private fun isTopLevelDeclarationConstant(node: ASTNode): Boolean {
+        if (node.treeParent.elementType == PROPERTY) {
+            return (node.treeParent.psi as KtProperty).isTopLevel && (node.treeParent.psi as KtProperty).modifierList?.node?.hasChildOfType(CONST_KEYWORD) ?: false
+        }
+        return false
     }
 
     @Suppress("ComplexMethod")

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/MagicNumberRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/MagicNumberRule.kt
@@ -48,18 +48,14 @@ class MagicNumberRule(configRules: List<RulesConfig>) : DiktatRule(
         val nodeText = node.treePrev?.let { if (it.elementType == OPERATION_REFERENCE && it.hasChildOfType(MINUS)) "-${node.text}" else node.text } ?: node.text
         val isIgnoreNumber = configuration.ignoreNumbers.contains(nodeText)
         val isHashFunction = node.parent({ it.elementType == FUN && it.isHashFun() }) != null
-        var isPropertyDeclaration = node.parent({ it.elementType == PROPERTY && !it.isNodeFromCompanionObject() }) != null
-        val isLocalVariable = node.parent({ it.isVarProperty() && (it.psi as KtProperty).isLocal }) != null
         val isConstant = node.parent({ it.elementType == PROPERTY && it.isConstant() }) != null
+        val isPropertyDeclaration = !isConstant && node.parent({ it.elementType == PROPERTY && !it.isNodeFromCompanionObject() }) != null
+        val isLocalVariable = node.parent({ it.isVarProperty() && (it.psi as KtProperty).isLocal }) != null
         val isCompanionObjectProperty = node.parent({ it.elementType == PROPERTY && it.isNodeFromCompanionObject() }) != null
         val isEnums = node.parent({ it.elementType == ENUM_ENTRY }) != null
         val isRanges = node.treeParent.run {
             this.elementType == BINARY_EXPRESSION &&
                     this.findChildByType(OPERATION_REFERENCE)?.hasChildOfType(RANGE) ?: false
-        }
-        if (isConstant) {
-            // excluding const properties
-            isPropertyDeclaration = false
         }
         val isExtensionFunctions = node.parent({ it.elementType == FUN && (it.psi as KtFunction).isExtensionDeclaration() }) != null &&
                 node.parents().find { it.elementType == PROPERTY } == null

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/MagicNumberRuleWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/MagicNumberRuleWarnTest.kt
@@ -96,6 +96,23 @@ class MagicNumberRuleWarnTest : LintTestBase(::MagicNumberRule) {
 
     @Test
     @Tag(WarningNames.MAGIC_NUMBER)
+    fun `check ignore top level constants`() {
+        lintMethod(
+            """
+            |const val topLevel = 31
+            |
+            |val shouldTrigger = 32
+            |
+            |fun some() {
+            |
+            |}
+            """.trimMargin(),
+            LintError(3, 21, ruleId, "${MAGIC_NUMBER.warnText()} 32", false),
+        )
+    }
+
+    @Test
+    @Tag(WarningNames.MAGIC_NUMBER)
     fun `check all param in config true`() {
         lintMethod(
             """


### PR DESCRIPTION
### What's done:
  * Fixed bug


This pull request closes #841 
