### PR TITLE
Removing System.exit(1)

### DIFF
--- a/diktat-gradle-plugin/src/main/kotlin/org/cqfn/diktat/plugin/gradle/DiktatJavaExecTaskBase.kt
+++ b/diktat-gradle-plugin/src/main/kotlin/org/cqfn/diktat/plugin/gradle/DiktatJavaExecTaskBase.kt
@@ -3,7 +3,6 @@ package org.cqfn.diktat.plugin.gradle
 import org.cqfn.diktat.plugin.gradle.DiktatGradlePlugin.Companion.DIKTAT_CHECK_TASK
 import org.cqfn.diktat.plugin.gradle.DiktatGradlePlugin.Companion.DIKTAT_FIX_TASK
 import org.cqfn.diktat.ruleset.rules.DIKTAT_CONF_PROPERTY
-import org.cqfn.diktat.ruleset.utils.log
 
 import generated.DIKTAT_VERSION
 import generated.KTLINT_VERSION
@@ -16,6 +15,7 @@ import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.VerificationTask
 import org.gradle.util.GradleVersion
+import org.slf4j.LoggerFactory
 
 import java.io.File
 import javax.inject.Inject
@@ -175,6 +175,10 @@ open class DiktatJavaExecTaskBase @Inject constructor(
                 firstOrNull { it.exists() } ?: first()
             }
             .absolutePath
+    }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(DiktatJavaExecTaskBase::class.java)
     }
 }
 

--- a/diktat-gradle-plugin/src/main/kotlin/org/cqfn/diktat/plugin/gradle/DiktatJavaExecTaskBase.kt
+++ b/diktat-gradle-plugin/src/main/kotlin/org/cqfn/diktat/plugin/gradle/DiktatJavaExecTaskBase.kt
@@ -15,7 +15,6 @@ import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.VerificationTask
 import org.gradle.util.GradleVersion
-import org.slf4j.LoggerFactory
 
 import java.io.File
 import javax.inject.Inject
@@ -58,12 +57,12 @@ open class DiktatJavaExecTaskBase @Inject constructor(
         classpath = diktatConfiguration
         project.logger.debug("Setting diktatCheck classpath to ${diktatConfiguration.dependencies.toSet()}")
         if (diktatExtension.debug) {
-            logger.lifecycle("Running diktat $DIKTAT_VERSION with ktlint $KTLINT_VERSION")
+            project.logger.lifecycle("Running diktat $DIKTAT_VERSION with ktlint $KTLINT_VERSION")
         }
         ignoreFailures = diktatExtension.ignoreFailures
         isIgnoreExitValue = ignoreFailures  // ignore returned value of JavaExec started process if lint errors shouldn't fail the build
         systemProperty(DIKTAT_CONF_PROPERTY, resolveConfigFile(diktatExtension.diktatConfigFile).also {
-            logger.info("Setting system property for diktat config to $it")
+            project.logger.info("Setting system property for diktat config to $it")
         })
         args = additionalFlags.toMutableList().apply {
             if (diktatExtension.debug) {
@@ -77,7 +76,7 @@ open class DiktatJavaExecTaskBase @Inject constructor(
                          If ktlint receives empty patterns, it implicitly uses &#42;&#42;/*.kt, **/*.kts instead.
                          This can lead to diktat analyzing gradle buildscripts and so on. We want to prevent it.
                         */
-                        logger.warn("Inputs for $name do not exist, will not run diktat")
+                        project.logger.warn("Inputs for $name do not exist, will not run diktat")
                         shouldRun = false
                     }
                 }
@@ -91,7 +90,7 @@ open class DiktatJavaExecTaskBase @Inject constructor(
 
             add(createReporterFlag(diktatExtension))
         }
-        logger.debug("Setting JavaExec args to $args")
+        project.logger.debug("Setting JavaExec args to $args")
     }
 
     @TaskAction
@@ -99,7 +98,7 @@ open class DiktatJavaExecTaskBase @Inject constructor(
         if (shouldRun) {
             super.exec()
         } else {
-            logger.info("Skipping diktat execution")
+            project.logger.info("Skipping diktat execution")
         }
     }
 
@@ -137,14 +136,14 @@ open class DiktatJavaExecTaskBase @Inject constructor(
             val name = diktatExtension.reporterType.split(":")[1]
             val jarPath = diktatExtension.reporterType.split(":")[2]
             if (name.isEmpty() || jarPath.isEmpty()) {
-                log.warn("Either name or path to jar is not specified. Falling to plain reporter")
+                project.logger.warn("Either name or path to jar is not specified. Falling to plain reporter")
                 flag.append("--reporter=plain")
             } else {
                 flag.append("--reporter=$name,artifact=$jarPath")
             }
         } else {
             flag.append("--reporter=plain")
-            log.debug("Unknown reporter was specified. Falling back to plain reporter.")
+            project.logger.debug("Unknown reporter was specified. Falling back to plain reporter.")
         }
     }
 
@@ -175,10 +174,6 @@ open class DiktatJavaExecTaskBase @Inject constructor(
                 firstOrNull { it.exists() } ?: first()
             }
             .absolutePath
-    }
-
-    companion object {
-        private val log = LoggerFactory.getLogger(DiktatJavaExecTaskBase::class.java)
     }
 }
 

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/DiktatRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/DiktatRule.kt
@@ -32,6 +32,7 @@ abstract class DiktatRule(id: String,
      */
     lateinit var emitWarn: EmitType
 
+    @Suppress("TooGenericExceptionThrown")
     override fun visit(node: ASTNode,
                        autoCorrect: Boolean,
                        emit: EmitType) {
@@ -46,6 +47,9 @@ abstract class DiktatRule(id: String,
             } catch (internalError: Throwable) {
                 log.error("Internal error has occurred in $id. Please make an issue on this bug at https://github.com/cqfn/diKTat/.", internalError)
                 log.error("As a workaround you can disable these inspections in yml config: $inspections")
+                // we are very sorry for throwing common Error here, but unfortunately we are not able to throw
+                // any existing Exception, as they will be caught in ktlint framework and the logging will be confusing:
+                // it will incorrectly ask you to report issues in diktat to ktlint
                 throw Error("Internal error in diktat application")
             }
         }

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/DiktatRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/DiktatRule.kt
@@ -3,11 +3,11 @@ package org.cqfn.diktat.ruleset.rules
 import org.cqfn.diktat.common.config.rules.RulesConfig
 import org.cqfn.diktat.common.config.rules.isRuleEnabled
 import org.cqfn.diktat.ruleset.constants.EmitType
-import org.cqfn.diktat.ruleset.utils.log
+import org.cqfn.diktat.ruleset.rules.chapter1.PackageNaming
 
 import com.pinterest.ktlint.core.Rule
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
-import kotlin.system.exitProcess
+import org.slf4j.LoggerFactory
 
 private typealias DiktatConfigRule = org.cqfn.diktat.common.config.rules.Rule
 
@@ -46,7 +46,7 @@ abstract class DiktatRule(id: String,
             } catch (internalError: Throwable) {
                 log.error("Internal error has occurred in $id. Please make an issue on this bug at https://github.com/cqfn/diKTat/.", internalError)
                 log.error("As a workaround you can disable these inspections in yml config: $inspections")
-                exitProcess(1)
+                throw Error("Internal error in diktat application")
             }
         }
     }
@@ -60,4 +60,8 @@ abstract class DiktatRule(id: String,
      * @param node node that are coming from visit
      */
     abstract fun logic(node: ASTNode)
+
+    companion object {
+        private val log = LoggerFactory.getLogger(DiktatRule::class.java)
+    }
 }

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter2/comments/HeaderCommentRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter2/comments/HeaderCommentRule.kt
@@ -14,7 +14,6 @@ import org.cqfn.diktat.ruleset.utils.findChildAfter
 import org.cqfn.diktat.ruleset.utils.findChildBefore
 import org.cqfn.diktat.ruleset.utils.getAllChildrenWithType
 import org.cqfn.diktat.ruleset.utils.getFirstChildWithType
-import org.cqfn.diktat.ruleset.utils.log
 import org.cqfn.diktat.ruleset.utils.moveChildBefore
 
 import com.pinterest.ktlint.core.ast.ElementType
@@ -28,6 +27,7 @@ import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafElement
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.PsiWhiteSpaceImpl
+import org.slf4j.LoggerFactory
 
 import java.time.LocalDate
 
@@ -233,6 +233,7 @@ class HeaderCommentRule(configRules: List<RulesConfig>) : DiktatRule(
     }
 
     companion object {
+        private val log = LoggerFactory.getLogger(HeaderCommentRule::class.java)
         val hyphenRegex = Regex("""\d+-\d+""")
         val afterCopyrightRegex = Regex("""((©|\([cC]\))+ *\d+)""")
         val curYear = LocalDate.now().year

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/TrailingCommaRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/TrailingCommaRule.kt
@@ -6,7 +6,7 @@ import org.cqfn.diktat.common.config.rules.getCommonConfiguration
 import org.cqfn.diktat.common.config.rules.getRuleConfig
 import org.cqfn.diktat.ruleset.constants.Warnings.TRAILING_COMMA
 import org.cqfn.diktat.ruleset.rules.DiktatRule
-import org.cqfn.diktat.ruleset.utils.log
+import org.cqfn.diktat.ruleset.rules.chapter2.comments.HeaderCommentRule
 
 import com.pinterest.ktlint.core.ast.ElementType.COLLECTION_LITERAL_EXPRESSION
 import com.pinterest.ktlint.core.ast.ElementType.COMMA
@@ -33,6 +33,7 @@ import com.pinterest.ktlint.core.ast.isWhiteSpaceWithNewline
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 import org.jetbrains.kotlin.psi.psiUtil.siblings
+import org.slf4j.LoggerFactory
 
 /**
  * [1] Enumerations (In another rule)
@@ -119,6 +120,7 @@ class TrailingCommaRule(configRules: List<RulesConfig>) : DiktatRule(
     }
 
     companion object {
+        private val log = LoggerFactory.getLogger(TrailingCommaRule::class.java)
         val ktVersion = KotlinVersion(1, 4)
         val whenChildrenTypes = listOf(WHEN_CONDITION_WITH_EXPRESSION, WHEN_CONDITION_IS_PATTERN, WHEN_CONDITION_IN_RANGE)
     }

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/TrailingCommaRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/TrailingCommaRule.kt
@@ -6,7 +6,6 @@ import org.cqfn.diktat.common.config.rules.getCommonConfiguration
 import org.cqfn.diktat.common.config.rules.getRuleConfig
 import org.cqfn.diktat.ruleset.constants.Warnings.TRAILING_COMMA
 import org.cqfn.diktat.ruleset.rules.DiktatRule
-import org.cqfn.diktat.ruleset.rules.chapter2.comments.HeaderCommentRule
 
 import com.pinterest.ktlint.core.ast.ElementType.COLLECTION_LITERAL_EXPRESSION
 import com.pinterest.ktlint.core.ast.ElementType.COMMA

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/files/IndentationRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/files/IndentationRule.kt
@@ -8,7 +8,6 @@ import org.cqfn.diktat.common.config.rules.RulesConfig
 import org.cqfn.diktat.common.config.rules.getRuleConfig
 import org.cqfn.diktat.ruleset.constants.Warnings.WRONG_INDENTATION
 import org.cqfn.diktat.ruleset.rules.DiktatRule
-import org.cqfn.diktat.ruleset.rules.chapter2.comments.HeaderCommentRule
 import org.cqfn.diktat.ruleset.utils.getAllChildrenWithType
 import org.cqfn.diktat.ruleset.utils.getAllLeafsWithSpecificType
 import org.cqfn.diktat.ruleset.utils.getFilePath

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/files/IndentationRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/files/IndentationRule.kt
@@ -8,6 +8,7 @@ import org.cqfn.diktat.common.config.rules.RulesConfig
 import org.cqfn.diktat.common.config.rules.getRuleConfig
 import org.cqfn.diktat.ruleset.constants.Warnings.WRONG_INDENTATION
 import org.cqfn.diktat.ruleset.rules.DiktatRule
+import org.cqfn.diktat.ruleset.rules.chapter2.comments.HeaderCommentRule
 import org.cqfn.diktat.ruleset.utils.getAllChildrenWithType
 import org.cqfn.diktat.ruleset.utils.getAllLeafsWithSpecificType
 import org.cqfn.diktat.ruleset.utils.getFilePath
@@ -24,7 +25,6 @@ import org.cqfn.diktat.ruleset.utils.indentation.KdocIndentationChecker
 import org.cqfn.diktat.ruleset.utils.indentation.SuperTypeListChecker
 import org.cqfn.diktat.ruleset.utils.indentation.ValueParameterListChecker
 import org.cqfn.diktat.ruleset.utils.leaveOnlyOneNewLine
-import org.cqfn.diktat.ruleset.utils.log
 
 import com.pinterest.ktlint.core.ast.ElementType.CALL_EXPRESSION
 import com.pinterest.ktlint.core.ast.ElementType.DOT_QUALIFIED_EXPRESSION
@@ -60,7 +60,10 @@ import org.jetbrains.kotlin.psi.psiUtil.parents
 import org.jetbrains.kotlin.psi.psiUtil.parentsWithSelf
 import org.jetbrains.kotlin.psi.psiUtil.startOffset
 import org.jetbrains.kotlin.utils.addToStdlib.firstNotNullResult
+import org.slf4j.LoggerFactory
+
 import java.lang.StringBuilder
+
 import kotlin.math.abs
 
 /**
@@ -377,6 +380,7 @@ class IndentationRule(configRules: List<RulesConfig>) : DiktatRule(
     }
 
     companion object {
+        private val log = LoggerFactory.getLogger(IndentationRule::class.java)
         const val INDENT_SIZE = 4
         private val increasingTokens = listOf(LPAR, LBRACE, LBRACKET, LONG_TEMPLATE_ENTRY_START)
         private val decreasingTokens = listOf(RPAR, RBRACE, RBRACKET, LONG_TEMPLATE_ENTRY_END)

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/files/NewlinesRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/files/NewlinesRule.kt
@@ -20,7 +20,6 @@ import org.cqfn.diktat.ruleset.utils.isEol
 import org.cqfn.diktat.ruleset.utils.isFollowedByNewline
 import org.cqfn.diktat.ruleset.utils.isSingleLineIfElse
 import org.cqfn.diktat.ruleset.utils.leaveOnlyOneNewLine
-import org.cqfn.diktat.ruleset.utils.log
 
 import com.pinterest.ktlint.core.ast.ElementType.ANDAND
 import com.pinterest.ktlint.core.ast.ElementType.ARROW
@@ -94,6 +93,7 @@ import org.jetbrains.kotlin.psi.KtValueArgumentList
 import org.jetbrains.kotlin.psi.psiUtil.children
 import org.jetbrains.kotlin.psi.psiUtil.parents
 import org.jetbrains.kotlin.psi.psiUtil.siblings
+import org.slf4j.LoggerFactory
 
 /**
  * Rule that checks line break styles.
@@ -612,6 +612,7 @@ class NewlinesRule(configRules: List<RulesConfig>) : DiktatRule(
     }
 
     companion object {
+        private val log = LoggerFactory.getLogger(NewlinesRule::class.java)
         const val MAX_CALLS_IN_ONE_LINE = 3
 
         // fixme: these token sets can be not full, need to add new once as corresponding cases are discovered.

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/files/WhiteSpaceRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/files/WhiteSpaceRule.kt
@@ -3,8 +3,8 @@ package org.cqfn.diktat.ruleset.rules.chapter3.files
 import org.cqfn.diktat.common.config.rules.RulesConfig
 import org.cqfn.diktat.ruleset.constants.Warnings.WRONG_WHITESPACE
 import org.cqfn.diktat.ruleset.rules.DiktatRule
+import org.cqfn.diktat.ruleset.rules.chapter6.classes.CompactInitialization
 import org.cqfn.diktat.ruleset.utils.hasChildOfType
-import org.cqfn.diktat.ruleset.utils.log
 
 import com.pinterest.ktlint.core.ast.ElementType.ANNOTATION_ENTRY
 import com.pinterest.ktlint.core.ast.ElementType.ARROW
@@ -76,6 +76,7 @@ import org.jetbrains.kotlin.psi.KtPostfixExpression
 import org.jetbrains.kotlin.psi.KtPrefixExpression
 import org.jetbrains.kotlin.psi.psiUtil.parents
 import org.jetbrains.kotlin.psi.psiUtil.parentsWithSelf
+import org.slf4j.LoggerFactory
 
 /**
  * This rule checks usage of whitespaces for horizontal code separation
@@ -417,6 +418,8 @@ class WhiteSpaceRule(configRules: List<RulesConfig>) : DiktatRule(
             }
 
     companion object {
+        private val log = LoggerFactory.getLogger(CompactInitialization::class.java)
+
         private const val NUM_PARENTS_FOR_LAMBDA = 3  // this is the number of parent nodes needed to check if this node is lambda from argument list
         private val keywordsWithSpaceAfter = TokenSet.create(
             // these keywords are followed by {

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/classes/CompactInitialization.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/classes/CompactInitialization.kt
@@ -5,7 +5,6 @@ import org.cqfn.diktat.ruleset.constants.Warnings.COMPACT_OBJECT_INITIALIZATION
 import org.cqfn.diktat.ruleset.rules.DiktatRule
 import org.cqfn.diktat.ruleset.utils.KotlinParser
 import org.cqfn.diktat.ruleset.utils.getFunctionName
-import org.cqfn.diktat.ruleset.utils.log
 
 import com.pinterest.ktlint.core.ast.ElementType.LBRACE
 import com.pinterest.ktlint.core.ast.ElementType.WHITE_SPACE
@@ -20,6 +19,7 @@ import org.jetbrains.kotlin.psi.KtNameReferenceExpression
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.psiUtil.siblings
 import org.jetbrains.kotlin.psi.psiUtil.startOffset
+import org.slf4j.LoggerFactory
 
 /**
  * This rules checks if an object initialization can be wrapped into an `apply` function.
@@ -157,5 +157,9 @@ class CompactInitialization(configRules: List<RulesConfig>) : DiktatRule(
                     log.warn("apply with unexpected parameters: ${applyExpression.text}")
                 }
         }
+    }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(CompactInitialization::class.java)
     }
 }

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/AstNodeUtils.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/AstNodeUtils.kt
@@ -59,7 +59,7 @@ import org.slf4j.LoggerFactory
 /**
  * A [Logger] that can be used throughout diktat
  */
-val log: Logger = LoggerFactory.getLogger(ASTNode::class.java)
+private val log: Logger = LoggerFactory.getLogger("AstNodeUtil")
 
 /**
  * A class that represents result of nodes swapping. [oldNodes] should always have same size as [newNodes]

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/StringCaseUtils.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/StringCaseUtils.kt
@@ -3,6 +3,9 @@
 package org.cqfn.diktat.ruleset.utils
 
 import com.google.common.base.CaseFormat
+import org.slf4j.LoggerFactory
+
+private val log = LoggerFactory.getLogger("StringCaseUtils")
 
 /**
  * Available cases to name enum members

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/ClassLikeStructuresOrderRuleWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/ClassLikeStructuresOrderRuleWarnTest.kt
@@ -8,7 +8,6 @@ import org.cqfn.diktat.util.LintTestBase
 
 import com.pinterest.ktlint.core.LintError
 import generated.WarningNames
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/util/TestUtils.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/util/TestUtils.kt
@@ -6,7 +6,6 @@ package org.cqfn.diktat.util
 
 import org.cqfn.diktat.common.config.rules.RulesConfig
 import org.cqfn.diktat.ruleset.constants.EmitType
-import org.cqfn.diktat.ruleset.utils.log
 
 import com.pinterest.ktlint.core.KtLint
 import com.pinterest.ktlint.core.LintError
@@ -16,13 +15,15 @@ import com.pinterest.ktlint.core.RuleSetProvider
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.SoftAssertions
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
-import org.jetbrains.kotlin.konan.file.File
+import org.slf4j.LoggerFactory
 
 import java.util.concurrent.atomic.AtomicInteger
 
 internal const val TEST_FILE_NAME = "TestFileName.kt"
 
 typealias LintErrorCallback = (LintError, Boolean) -> Unit
+
+private val log = LoggerFactory.getLogger("TestUtils")
 
 @Suppress("TYPE_ALIAS")
 internal val defaultCallback: (lintError: LintError, corrected: Boolean) -> Unit = { lintError, _ ->


### PR DESCRIPTION
### What's done:
- we decided to remove System.exit(1) because of the diktat demo #860
- fixed logging


Closes #860 