### PR TITLE
Fix bug in PackageNaming for kotlin scripts

### DIFF
--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/ClassLikeStructuresOrderRuleWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/ClassLikeStructuresOrderRuleWarnTest.kt
@@ -8,7 +8,6 @@ import org.cqfn.diktat.util.LintTestBase
 
 import com.pinterest.ktlint.core.LintError
 import generated.WarningNames
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/smoke/DiktatSmokeTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/smoke/DiktatSmokeTest.kt
@@ -26,7 +26,9 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 
+import java.io.File
 import java.time.LocalDate
+
 import kotlin.io.path.ExperimentalPathApi
 import kotlin.io.path.createTempFile
 import kotlinx.serialization.encodeToString
@@ -204,10 +206,24 @@ class DiktatSmokeTest : FixTestBase("test/smoke/src/main/kotlin",
                     "extendedIndentOfParameters" to "false",
                 )
             )
-        )  // so that trailing newline isn't checked
+        )  // so that trailing newline isn't checked, because it's incorrectly read in tests and we are comparing file with itself
         // file name is `gradle_` so that IDE doesn't suggest to import gradle project
-        fixAndCompare("../../../build.gradle_.kts", "../../../build.gradle_.kts")
+        val tmpTestFile = javaClass.classLoader.getResource("$resourceFilePath/../../../build.gradle_.kts")!!.toURI().let {
+            val tmpTestFile = File(it).parentFile.resolve("build.gradle.kts")
+            File(it).copyTo(tmpTestFile)
+            tmpTestFile
+        }
+        val tmpFilePath = "../../../build.gradle.kts"
+        fixAndCompare(tmpFilePath, tmpFilePath)
         Assertions.assertTrue(unfixedLintErrors.isEmpty())
+        tmpTestFile.delete()
+    }
+
+    @Test
+    @Tag("DiktatRuleSetProvider")
+    fun `smoke test with kts files #2`() {
+        fixAndCompare("script/SimpleRunInScriptExpected.kts", "script/SimpleRunInScriptTest.kts")
+        Assertions.assertEquals(3, unfixedLintErrors.size)
     }
 
     @Test

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/smoke/DiktatSmokeTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/smoke/DiktatSmokeTest.kt
@@ -228,6 +228,13 @@ class DiktatSmokeTest : FixTestBase("test/smoke/src/main/kotlin",
 
     @Test
     @Tag("DiktatRuleSetProvider")
+    fun `smoke test with kts files with package name`() {
+        fixAndCompare("script/PackageInScriptExpected.kts", "script/PackageInScriptTest.kts")
+        Assertions.assertEquals(3, unfixedLintErrors.size)
+    }
+
+    @Test
+    @Tag("DiktatRuleSetProvider")
     fun `disable charters`() {
         overrideRulesConfig(
             emptyList(),

--- a/diktat-rules/src/test/resources/test/smoke/src/main/kotlin/script/PackageInScriptExpected.kts
+++ b/diktat-rules/src/test/resources/test/smoke/src/main/kotlin/script/PackageInScriptExpected.kts
@@ -1,0 +1,20 @@
+package org.cqfn.diktat.script
+
+run {
+    println("hello world!")
+}
+
+fun foo() {
+    println()
+}
+
+val q = Config()
+
+run {
+    println("a")
+}
+
+also {
+    println("a")
+}
+

--- a/diktat-rules/src/test/resources/test/smoke/src/main/kotlin/script/PackageInScriptTest.kts
+++ b/diktat-rules/src/test/resources/test/smoke/src/main/kotlin/script/PackageInScriptTest.kts
@@ -1,0 +1,19 @@
+package org.cqfn.diktat.script
+
+run {
+    println("hello world!")
+}
+
+fun foo() {
+    println()
+}
+
+val q = Config()
+
+run {
+    println("a")
+}
+
+also {
+    println("a")
+}

--- a/diktat-rules/src/test/resources/test/smoke/src/main/kotlin/script/SimpleRunInScriptExpected.kts
+++ b/diktat-rules/src/test/resources/test/smoke/src/main/kotlin/script/SimpleRunInScriptExpected.kts
@@ -16,3 +16,4 @@ run {
 also {
     println("a")
 }
+

--- a/diktat-rules/src/test/resources/test/smoke/src/main/kotlin/script/SimpleRunInScriptExpected.kts
+++ b/diktat-rules/src/test/resources/test/smoke/src/main/kotlin/script/SimpleRunInScriptExpected.kts
@@ -1,0 +1,18 @@
+
+run {
+    println("hello world!")
+}
+
+fun foo() {
+    println()
+}
+
+val q = Config()
+
+run {
+    println("a")
+}
+
+also {
+    println("a")
+}

--- a/diktat-rules/src/test/resources/test/smoke/src/main/kotlin/script/SimpleRunInScriptTest.kts
+++ b/diktat-rules/src/test/resources/test/smoke/src/main/kotlin/script/SimpleRunInScriptTest.kts
@@ -1,0 +1,16 @@
+
+println("hello world!")
+
+fun foo() {
+    println()
+}
+
+val q = Config()
+
+run {
+    println("a")
+}
+
+also {
+    println("a")
+}


### PR DESCRIPTION
### What's done:
* Changed logic
* Updated smoke tests

This pull request closes #861 