### PR TITLE
Bugfix. Unused_import rule should ignore all standard operator funs

### DIFF
--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/files/FileStructureRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/files/FileStructureRule.kt
@@ -73,12 +73,7 @@ class FileStructureRule(configRules: List<RulesConfig>) : DiktatRule(
         }
     private val refSet: MutableSet<String> = mutableSetOf()
     private var packageName = ""
-    private val ignoreImports = setOf("invoke", "get", "set")
-
-    // Fixme: this imports should be deleted if unused
-    private val ignoreOperators = setOf("getValue", "plus", "minus", "times", "div",
-        "rem", "rangeTo", "contains", "plusAssign", "minusAssign", "timesAssign",
-        "divAssign", "remAssign", "compareTo", "inc", "dec", "unaryPlus", "unaryMinus", "not")
+    private val ignoreImports = setOf("invoke", "get", "set", "getValue")
 
     override fun logic(node: ASTNode) {
         if (node.elementType == FILE) {
@@ -231,8 +226,9 @@ class FileStructureRule(configRules: List<RulesConfig>) : DiktatRule(
                 ) {
                     // this branch corresponds to imports from the same package
                     deleteImport(importPath, node, ktImportDirective)
-                } else if (importName != null && !ignoreImports.contains(importName) && !refSet.contains(importName) && !ignoreOperators.contains(importName)) {
+                } else if (importName != null && !ignoreImports.contains(importName) && !refSet.contains(importName) && !operatorMap.containsKey(importName)) {
                     // this import is not used anywhere
+                    // Fixme: operatorMap imports and `getValue` should be deleted if unused
                     deleteImport(importPath, node, ktImportDirective)
                 }
             }

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/files/FileStructureRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/files/FileStructureRule.kt
@@ -75,6 +75,11 @@ class FileStructureRule(configRules: List<RulesConfig>) : DiktatRule(
     private var packageName = ""
     private val ignoreImports = setOf("invoke", "get", "set")
 
+    // Fixme: this imports should be deleted if unused
+    private val ignoreOperators = setOf("getValue", "plus", "minus", "times", "div",
+        "rem", "rangeTo", "contains", "plusAssign", "minusAssign", "timesAssign",
+        "divAssign", "remAssign", "compareTo", "inc", "dec", "unaryPlus", "unaryMinus", "not")
+
     override fun logic(node: ASTNode) {
         if (node.elementType == FILE) {
             val wildcardImportsConfig = WildCardImportsConfig(
@@ -226,10 +231,7 @@ class FileStructureRule(configRules: List<RulesConfig>) : DiktatRule(
                 ) {
                     // this branch corresponds to imports from the same package
                     deleteImport(importPath, node, ktImportDirective)
-                } else if (importName != null && !ignoreImports.contains(importName) && !refSet.contains(
-                    importName
-                )
-                ) {
+                } else if (importName != null && !ignoreImports.contains(importName) && !refSet.contains(importName) && !ignoreOperators.contains(importName)) {
                     // this import is not used anywhere
                     deleteImport(importPath, node, ktImportDirective)
                 }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/FileStructureRuleTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/FileStructureRuleTest.kt
@@ -13,6 +13,7 @@ import org.cqfn.diktat.util.LintTestBase
 
 import com.pinterest.ktlint.core.LintError
 import generated.WarningNames
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 
@@ -392,6 +393,85 @@ class FileStructureRuleTest : LintTestBase(::FileStructureRule) {
                 |   val a = list[1]
                 |}
             """.trimMargin(),
+        )
+    }
+
+    @Test
+    @Tag(WarningNames.UNUSED_IMPORT)
+    fun `check by #1`() {
+        lintMethod(
+            """
+                |package org.cqfn.diktat.example
+                |
+                |import com.example.get
+                |import com.example.invoke
+                |import com.example.set
+                |import kotlin.properties.Delegates
+                |
+                |fun main() {
+                |   val a by Delegates.observable()
+                |}
+            """.trimMargin(),
+        )
+    }
+
+    @Test
+    @Tag(WarningNames.UNUSED_IMPORT)
+    fun `check by #2 should not trigger`() {
+        lintMethod(
+            """
+                |package org.cqfn.diktat.example
+                |
+                |import com.example.get
+                |import com.example.invoke
+                |import com.example.set
+                |import tasks.getValue
+                |
+                |fun main() {
+                |   val a by tasks.getting
+                |}
+            """.trimMargin(),
+        )
+    }
+
+    @Test
+    @Tag(WarningNames.UNUSED_IMPORT)
+    fun `check by #3 should trigger`() {
+        lintMethod(
+            """
+                |package org.cqfn.diktat.example
+                |
+                |import Delegate
+                |import com.example.get
+                |import com.example.invoke
+                |import com.example.set
+                |
+                |fun main() {
+                |   val a
+                |}
+            """.trimMargin(),
+            LintError(1, 1, ruleId, "${Warnings.UNUSED_IMPORT.warnText()} Delegate - unused import", true)
+        )
+    }
+
+    @Disabled
+    @Test
+    @Tag(WarningNames.UNUSED_IMPORT)
+    fun `check by #4 should trigger`() {
+        lintMethod(
+            """
+                |package org.cqfn.diktat.example
+                |
+                |import com.example.get
+                |import com.example.invoke
+                |import com.example.set
+                |import tasks.getValue
+                |
+                |fun main() {
+                |   val a
+                |}
+            """.trimMargin(),
+            LintError(1, 1, ruleId, "${Warnings.UNUSED_IMPORT.warnText()} tasks.getValue - unused import", true)
         )
     }
 }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/FileStructureRuleTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/FileStructureRuleTest.kt
@@ -454,6 +454,7 @@ class FileStructureRuleTest : LintTestBase(::FileStructureRule) {
         )
     }
 
+    // Fixme: This test is not passing because for now we don't have type resolution
     @Disabled
     @Test
     @Tag(WarningNames.UNUSED_IMPORT)


### PR DESCRIPTION
### What's done:
  * Fixed bug
  * Added test

This pull request closes #837 
