### PR TITLE
Logging of file name in DiktatRule is unreliable

### DIFF
--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter1/PackageNaming.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter1/PackageNaming.kt
@@ -53,7 +53,7 @@ class PackageNaming(configRules: List<RulesConfig>) : DiktatRule(
         configuration.domainName?.let {
             domainName = it
             if (node.elementType == PACKAGE_DIRECTIVE) {
-                val filePath = node.getRootNode().getFilePath()
+                val filePath = node.getFilePath()
 
                 // getting all identifiers from existing package name into the list like [org, diktat, project]
                 val wordsInPackageName = node.findAllDescendantsWithSpecificType(IDENTIFIER)

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter2/comments/HeaderCommentRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter2/comments/HeaderCommentRule.kt
@@ -15,7 +15,6 @@ import org.cqfn.diktat.ruleset.utils.findChildBefore
 import org.cqfn.diktat.ruleset.utils.getAllChildrenWithType
 import org.cqfn.diktat.ruleset.utils.getFilePath
 import org.cqfn.diktat.ruleset.utils.getFirstChildWithType
-import org.cqfn.diktat.ruleset.utils.getRootNode
 import org.cqfn.diktat.ruleset.utils.isGradleScript
 import org.cqfn.diktat.ruleset.utils.moveChildBefore
 
@@ -48,7 +47,7 @@ class HeaderCommentRule(configRules: List<RulesConfig>) : DiktatRule(
     listOf(HEADER_MISSING_IN_NON_SINGLE_CLASS_FILE, HEADER_MISSING_OR_WRONG_COPYRIGHT, HEADER_NOT_BEFORE_PACKAGE,
         HEADER_NOT_BEFORE_PACKAGE, HEADER_WRONG_FORMAT, WRONG_COPYRIGHT_YEAR)) {
     override fun logic(node: ASTNode) {
-        if (node.elementType == FILE && !node.getRootNode().getFilePath().isGradleScript()) {
+        if (node.elementType == FILE && !node.getFilePath().isGradleScript()) {
             checkCopyright(node)
             if (checkHeaderKdocPosition(node)) {
                 checkHeaderKdoc(node)

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter2/kdoc/KdocComments.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter2/kdoc/KdocComments.kt
@@ -54,7 +54,7 @@ class KdocComments(configRules: List<RulesConfig>) : DiktatRule(
      */
     override fun logic(node: ASTNode) {
         val config = configRules.getCommonConfiguration()
-        val filePath = node.getRootNode().getFilePath()
+        val filePath = node.getFilePath()
         if (!node.hasTestAnnotation() && !isLocatedInTest(filePath.splitPathToDirs(), config.testAnchors)) {
             when (node.elementType) {
                 FILE -> checkTopLevelDoc(node)

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter2/kdoc/KdocMethods.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter2/kdoc/KdocMethods.kt
@@ -16,7 +16,6 @@ import org.cqfn.diktat.ruleset.utils.getBodyLines
 import org.cqfn.diktat.ruleset.utils.getFilePath
 import org.cqfn.diktat.ruleset.utils.getFirstChildWithType
 import org.cqfn.diktat.ruleset.utils.getIdentifierName
-import org.cqfn.diktat.ruleset.utils.getRootNode
 import org.cqfn.diktat.ruleset.utils.hasChildOfType
 import org.cqfn.diktat.ruleset.utils.hasKnownKdocTag
 import org.cqfn.diktat.ruleset.utils.hasTestAnnotation
@@ -76,7 +75,7 @@ class KdocMethods(configRules: List<RulesConfig>) : DiktatRule(
     override fun logic(node: ASTNode) {
         if (node.elementType == FUN && node.getFirstChildWithType(MODIFIER_LIST).isAccessibleOutside() && !node.isOverridden()) {
             val config = configRules.getCommonConfiguration()
-            val filePath = node.getRootNode().getFilePath()
+            val filePath = node.getFilePath()
             val isTestMethod = node.hasTestAnnotation() || isLocatedInTest(filePath.splitPathToDirs(), config.testAnchors)
             if (!isTestMethod && !node.isStandardMethod() && !node.isSingleLineGetterOrSetter()) {
                 checkSignatureDescription(node)

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/MagicNumberRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/MagicNumberRule.kt
@@ -40,7 +40,7 @@ class MagicNumberRule(configRules: List<RulesConfig>) : DiktatRule(
     }
     @Suppress("COLLAPSE_IF_STATEMENTS")
     override fun logic(node: ASTNode) {
-        val filePath = node.getRootNode().getFilePath()
+        val filePath = node.getFilePath()
         val config = configRules.getCommonConfiguration()
         if (node.elementType == INTEGER_CONSTANT || node.elementType == FLOAT_CONSTANT) {
             if (!isLocatedInTest(filePath.splitPathToDirs(), config.testAnchors) || !configuration.isIgnoreTest) {

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/AvoidUtilityClass.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/AvoidUtilityClass.kt
@@ -31,7 +31,7 @@ class AvoidUtilityClass(configRules: List<RulesConfig>) : DiktatRule(
     listOf(AVOID_USING_UTILITY_CLASS)) {
     override fun logic(node: ASTNode) {
         val config = configRules.getCommonConfiguration()
-        val filePath = node.getRootNode().getFilePath()
+        val filePath = node.getFilePath()
         if (!node.hasTestAnnotation() && !isLocatedInTest(filePath.splitPathToDirs(), config.testAnchors)) {
             @Suppress("COLLAPSE_IF_STATEMENTS")
             if (node.elementType == OBJECT_DECLARATION || node.elementType == CLASS) {

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/RunInScript.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/RunInScript.kt
@@ -34,8 +34,8 @@ class RunInScript(private val configRules: List<RulesConfig>) : Rule("run-script
         isFixMode = autoCorrect
         emitWarn = emit
 
-        if (node.elementType == SCRIPT_INITIALIZER && node.getRootNode().getFilePath().isKotlinScript()) {
-            if (node.getRootNode().getFilePath().isGradleScript()) {
+        if (node.elementType == SCRIPT_INITIALIZER && node.getFilePath().isKotlinScript()) {
+            if (node.getFilePath().isGradleScript()) {
                 checkGradleNode(node)
             } else {
                 checkScript(node)

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/AstNodeUtils.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/AstNodeUtils.kt
@@ -737,12 +737,10 @@ fun ASTNode.calculateLineColByOffset() = buildPositionInTextLocator(text)
  *
  * @return name of the file [this] node belongs to
  */
-fun ASTNode.getFilePath(): String = getRootNode().let {
-    require(it.elementType == FILE) { "Root node type is not FILE" }
-    it
+fun ASTNode.getFilePath(): String = getRootNode().also {
+    require(it.elementType == FILE) { "Root node type is not FILE, but file_path is present in user_data only in FILE nodes" }
 }.getUserData(KtLint.FILE_PATH_USER_DATA_KEY).let {
     requireNotNull(it) { "File path is not present in user data" }
-    it
 }
 
 /**

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/AstNodeUtils.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/utils/AstNodeUtils.kt
@@ -737,7 +737,10 @@ fun ASTNode.calculateLineColByOffset() = buildPositionInTextLocator(text)
  *
  * @return name of the file [this] node belongs to
  */
-fun ASTNode.getFilePath(): String = getUserData(KtLint.FILE_PATH_USER_DATA_KEY).let {
+fun ASTNode.getFilePath(): String = getRootNode().let {
+    require(it.elementType == FILE) { "Root node type is not FILE" }
+    it
+}.getUserData(KtLint.FILE_PATH_USER_DATA_KEY).let {
     requireNotNull(it) { "File path is not present in user data" }
     it
 }


### PR DESCRIPTION
### What's done:
* added getRootNode() and require in getFilePath()
Closes #938