### PR TITLE
Diktat should avoid fixing/raising a warning an issue for override constructor arguments

### DIFF
--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter2/kdoc/KdocComments.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter2/kdoc/KdocComments.kt
@@ -161,7 +161,7 @@ class KdocComments(configRules: List<RulesConfig>) : DiktatRule(
 
     @Suppress("UnsafeCallOnNullableType")
     private fun createKdocBasicKdoc(node: ASTNode) {
-        if (node.getFirstChildWithType(MODIFIER_LIST).isAccessibleOutside()) {
+        if (node.getFirstChildWithType(MODIFIER_LIST).isAccessibleOutside() && !node.isOverridden()) {
             KDOC_NO_CONSTRUCTOR_PROPERTY.warnAndFix(configRules, emitWarn, isFixMode,
                 "add <${node.findChildByType(IDENTIFIER)!!.text}> to KDoc", node.startOffset, node) {
                 val newKdoc = KotlinParser().createNode("/**\n * @property ${node.findChildByType(IDENTIFIER)!!.text}\n */")

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter2/KdocCommentsWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter2/KdocCommentsWarnTest.kt
@@ -270,6 +270,19 @@ class KdocCommentsWarnTest : LintTestBase(::KdocComments) {
 
     @Test
     @Tag(WarningNames.KDOC_NO_CONSTRUCTOR_PROPERTY)
+    fun `shouldn't trigger on override parameter`() {
+        lintMethod(
+            """
+                    |@Suppress("MISSING_KDOC_TOP_LEVEL")
+                    |public class Example (
+                    |   override val serializersModule: SerializersModule = EmptySerializersModule
+                    |)
+                """.trimMargin()
+        )
+    }
+
+    @Test
+    @Tag(WarningNames.KDOC_NO_CONSTRUCTOR_PROPERTY)
     fun `shouldn't trigger because not primary constructor`() {
         lintMethod(
             """


### PR DESCRIPTION
### What's done:
* added check for override constructor arguments
Closes #833

