### PR TITLE
Support KDoc generation for rethrown exceptions

### DIFF
--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter2/kdoc/KdocMethods.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter2/kdoc/KdocMethods.kt
@@ -170,7 +170,9 @@ class KdocMethods(configRules: List<RulesConfig>) : DiktatRule(
             ?: emptySet()
     }
 
+    @Suppress("UnsafeCallOnNullableType")
     private fun getRethrownExceptions(node: ASTNode) = node.findAllDescendantsWithSpecificType(CATCH).flatMap { catchClauseNode ->
+        // `parameterList` is `@Nullable @IfNotParsed`
         (catchClauseNode.psi as KtCatchClause).parameterList!!.parameters
             .filter {
                 // `catch (_: Exception)` - parameter can be anonymous
@@ -182,7 +184,10 @@ class KdocMethods(configRules: List<RulesConfig>) : DiktatRule(
                     it.thrownExpression?.referenceExpression()?.text == param.name
                 } == true
             }
-            .map { it.typeReference!!.typeElement!!.text }
+            .map {
+                // parameter in catch statement `catch (e: Type)` should always have type
+                it.typeReference!!.text
+            }
     }
         .toSet()
 

--- a/diktat-rules/src/test/resources/test/paragraph2/kdoc/package/src/main/kotlin/org/cqfn/diktat/kdoc/methods/ThrowsTagInsertionExpected.kt
+++ b/diktat-rules/src/test/resources/test/paragraph2/kdoc/package/src/main/kotlin/org/cqfn/diktat/kdoc/methods/ThrowsTagInsertionExpected.kt
@@ -46,4 +46,22 @@ class Example {
         if (true) throw IllegalStateException("Lorem ipsum")
         else throw IllegalAccessException("Dolor sit amet")
     }
+
+    /**
+ * @throws RuntimeException
+ */
+fun test6() {
+        try {
+            foo()
+        } catch (_: NullPointerException) {
+            println("NPE!")
+        } catch (e: RuntimeException) {
+            println("Whoops...")
+            throw e
+        } catch (e: Error) {
+            val x = IllegalStateException()
+            println("Nothing to do here")
+            throw x
+        }
+    }
 }

--- a/diktat-rules/src/test/resources/test/paragraph2/kdoc/package/src/main/kotlin/org/cqfn/diktat/kdoc/methods/ThrowsTagInsertionTested.kt
+++ b/diktat-rules/src/test/resources/test/paragraph2/kdoc/package/src/main/kotlin/org/cqfn/diktat/kdoc/methods/ThrowsTagInsertionTested.kt
@@ -40,4 +40,19 @@ class Example {
         if (true) throw IllegalStateException("Lorem ipsum")
         else throw IllegalAccessException("Dolor sit amet")
     }
+
+    fun test6() {
+        try {
+            foo()
+        } catch (_: NullPointerException) {
+            println("NPE!")
+        } catch (e: RuntimeException) {
+            println("Whoops...")
+            throw e
+        } catch (e: Error) {
+            val x = IllegalStateException()
+            println("Nothing to do here")
+            throw x
+        }
+    }
 }


### PR DESCRIPTION
### What's done:
* Changed logic
* Added tests

This pull request closes #975

#### Fixme:
* We may also want throwing of local variables with exception type, e.g. `val x = IllegalStateException(); throw x`