### PR TITLE
Incorrect fix in COMPACT_OBJECT_INITIALIZATION rule

### DIFF
--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/classes/CompactInitialization.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/classes/CompactInitialization.kt
@@ -4,11 +4,14 @@ import org.cqfn.diktat.common.config.rules.RulesConfig
 import org.cqfn.diktat.ruleset.constants.Warnings.COMPACT_OBJECT_INITIALIZATION
 import org.cqfn.diktat.ruleset.rules.DiktatRule
 import org.cqfn.diktat.ruleset.utils.KotlinParser
+import org.cqfn.diktat.ruleset.utils.findAllDescendantsWithSpecificType
 import org.cqfn.diktat.ruleset.utils.findLeafWithSpecificType
 import org.cqfn.diktat.ruleset.utils.getFunctionName
 
 import com.pinterest.ktlint.core.ast.ElementType.BLOCK_COMMENT
+import com.pinterest.ktlint.core.ast.ElementType.CALL_EXPRESSION
 import com.pinterest.ktlint.core.ast.ElementType.EOL_COMMENT
+import com.pinterest.ktlint.core.ast.ElementType.IDENTIFIER
 import com.pinterest.ktlint.core.ast.ElementType.KDOC
 import com.pinterest.ktlint.core.ast.ElementType.LBRACE
 import com.pinterest.ktlint.core.ast.ElementType.THIS_KEYWORD
@@ -82,7 +85,10 @@ class CompactInitialization(configRules: List<RulesConfig>) : DiktatRule(
             }
     }
 
-    @Suppress("UnsafeCallOnNullableType", "NestedBlockDepth")
+    @Suppress(
+        "UnsafeCallOnNullableType",
+        "NestedBlockDepth",
+        "TOO_LONG_FUNCTION")
     private fun moveAssignmentIntoApply(property: KtProperty, assignment: KtBinaryExpression) {
         // get apply expression or create empty; convert `apply(::foo)` to `apply { foo(this) }` if necessary
         getOrCreateApplyBlock(property).let(::convertValueParametersToLambdaArgument)
@@ -114,6 +120,14 @@ class CompactInitialization(configRules: List<RulesConfig>) : DiktatRule(
                             }
                             it.treeParent.removeChild(it)
                         }
+                    val receiverName = assignment.text.substringBefore('.')
+                    // looking for usages of receiver in right part
+                    val identifiers = assignment.right!!.node.findAllDescendantsWithSpecificType(IDENTIFIER)
+                    identifiers.forEach {
+                        if (it.text == receiverName && it.treeParent.treeParent.elementType != CALL_EXPRESSION) {
+                            it.treeParent.replaceChild(it, kotlinParser.createNode("this"))
+                        }
+                    }
                     // strip receiver name and move assignment itself into `apply`
                     bodyExpression.addChild(kotlinParser.createNode(assignment.text.substringAfter('.')), null)
                     assignment.node.run { treeParent.removeChild(this) }

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/classes/CompactInitialization.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter6/classes/CompactInitialization.kt
@@ -11,9 +11,9 @@ import org.cqfn.diktat.ruleset.utils.getFunctionName
 import com.pinterest.ktlint.core.ast.ElementType.BLOCK_COMMENT
 import com.pinterest.ktlint.core.ast.ElementType.CALL_EXPRESSION
 import com.pinterest.ktlint.core.ast.ElementType.EOL_COMMENT
-import com.pinterest.ktlint.core.ast.ElementType.IDENTIFIER
 import com.pinterest.ktlint.core.ast.ElementType.KDOC
 import com.pinterest.ktlint.core.ast.ElementType.LBRACE
+import com.pinterest.ktlint.core.ast.ElementType.REFERENCE_EXPRESSION
 import com.pinterest.ktlint.core.ast.ElementType.THIS_KEYWORD
 import com.pinterest.ktlint.core.ast.ElementType.WHITE_SPACE
 import com.pinterest.ktlint.core.ast.isPartOfComment
@@ -120,11 +120,11 @@ class CompactInitialization(configRules: List<RulesConfig>) : DiktatRule(
                             }
                             it.treeParent.removeChild(it)
                         }
-                    val receiverName = assignment.text.substringBefore('.')
+                    val receiverName = (assignment.left as KtDotQualifiedExpression).receiverExpression
                     // looking for usages of receiver in right part
-                    val identifiers = assignment.right!!.node.findAllDescendantsWithSpecificType(IDENTIFIER)
+                    val identifiers = assignment.right!!.node.findAllDescendantsWithSpecificType(REFERENCE_EXPRESSION)
                     identifiers.forEach {
-                        if (it.text == receiverName && it.treeParent.treeParent.elementType != CALL_EXPRESSION) {
+                        if (it.text == receiverName.text && it.treeParent.elementType != CALL_EXPRESSION) {
                             it.treeParent.replaceChild(it, kotlinParser.createNode("this"))
                         }
                     }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter6/CompactInitializationFixTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter6/CompactInitializationFixTest.kt
@@ -31,4 +31,10 @@ class CompactInitializationFixTest : FixTestBase("test/chapter6/compact_initiali
     fun `should not move statements with this keyword into apply block`() {
         fixAndCompare("ApplyOnStatementsWithThisKeywordExpected.kt", "ApplyOnStatementsWithThisKeywordTest.kt")
     }
+
+    @Test
+    @Tag(WarningNames.COMPACT_OBJECT_INITIALIZATION)
+    fun `should rename field in apply block to this keyword`() {
+        fixAndCompare("StatementUseFieldMultipleTimesExpected.kt", "StatementUseFieldMultipleTimesTest.kt")
+    }
 }

--- a/diktat-rules/src/test/resources/test/chapter6/compact_initialization/StatementUseFieldMultipleTimesExpected.kt
+++ b/diktat-rules/src/test/resources/test/chapter6/compact_initialization/StatementUseFieldMultipleTimesExpected.kt
@@ -1,5 +1,14 @@
-private fun foo() {
+fun foo() {
     val execution = Execution().apply {
     id = executionService.saveExecution(this)}
+    return execution.id!!
+}
+
+fun foo() {
+    val execution = Execution().apply {
+    id = executionService.saveExecution(this)
+    sdk = this.defaultSdk(this)
+    id2 = this.id + shift
+    name = this.execution(this)}
     return execution.id!!
 }

--- a/diktat-rules/src/test/resources/test/chapter6/compact_initialization/StatementUseFieldMultipleTimesExpected.kt
+++ b/diktat-rules/src/test/resources/test/chapter6/compact_initialization/StatementUseFieldMultipleTimesExpected.kt
@@ -1,0 +1,5 @@
+private fun foo() {
+    val execution = Execution().apply {
+    id = executionService.saveExecution(this)}
+    return execution.id!!
+}

--- a/diktat-rules/src/test/resources/test/chapter6/compact_initialization/StatementUseFieldMultipleTimesTest.kt
+++ b/diktat-rules/src/test/resources/test/chapter6/compact_initialization/StatementUseFieldMultipleTimesTest.kt
@@ -1,5 +1,14 @@
-private fun foo() {
+fun foo() {
     val execution = Execution()
     execution.id = executionService.saveExecution(execution)
+    return execution.id!!
+}
+
+fun foo() {
+    val execution = Execution()
+    execution.id = executionService.saveExecution(execution)
+    execution.sdk = execution.defaultSdk(execution)
+    execution.id2 = execution.id + shift
+    execution.name = execution.execution(execution)
     return execution.id!!
 }

--- a/diktat-rules/src/test/resources/test/chapter6/compact_initialization/StatementUseFieldMultipleTimesTest.kt
+++ b/diktat-rules/src/test/resources/test/chapter6/compact_initialization/StatementUseFieldMultipleTimesTest.kt
@@ -1,0 +1,5 @@
+private fun foo() {
+    val execution = Execution()
+    execution.id = executionService.saveExecution(execution)
+    return execution.id!!
+}


### PR DESCRIPTION
### What's done:
* Fix bug and process case, when receiver name is also used in right part of expression
* Add tests